### PR TITLE
Feature/lab7

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -1,24 +1,35 @@
 ## Goal
 
-This PR delivers Lab 1: OWASP Juice Shop deployment, triage report, and course PR workflow setup.
+This PR delivers Lab N work: <briefly describe what this lab adds>.
 
 ## Changes
 
-- Added `submissions/lab1.md` with Juice Shop deployment and triage report.
-- Added `.github/PULL_REQUEST_TEMPLATE.md` for future lab submissions.
-- Documented testing commands, observations, security headers, risks, and GitHub community engagement.
+* Added/updated `submissions/labN.md`.
+* Added/updated lab-related configuration files.
+* Documented testing steps, observed output, and required artifacts.
 
 ## Testing
 
 Commands used:
 
 ```bash
-docker run -d --name juice-shop -p 127.0.0.1:3000:3000 bkimminich/juice-shop:v20.0.0
-docker ps --filter name=juice-shop
-curl -s -o /dev/null -w "HTTP %{http_code}\n" http://127.0.0.1:3000
-curl -s http://127.0.0.1:3000/api/Products | jq '.data | length'
-curl -s http://127.0.0.1:3000/rest/admin/application-version | jq
-curl -I http://127.0.0.1:3000 2>&1 | head -20
+<paste commands used to verify the lab>
 ```
-Observed result: Juice Shop started successfully, homepage returned HTTP 200, and API/version endpoints responded.
+
+Observed output:
+
+```text
+<paste important output here>
+```
+
+## Artifacts & Screenshots
+
+* `submissions/labN.md`
+* <add links to screenshots, workflow runs, or other artifacts if needed>
+
+## Checklist
+
+* [ ] Title is clear (`feat(labN): <topic>` style)
+* [ ] No secrets/large temp files committed
+* [ ] Submission file at `submissions/labN.md` exists
 

--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -1,0 +1,23 @@
+## Goal
+
+This PR delivers Lab 1: OWASP Juice Shop deployment, triage report, and course PR workflow setup.
+
+## Changes
+
+- Added `submissions/lab1.md` with Juice Shop deployment and triage report.
+- Added `.github/PULL_REQUEST_TEMPLATE.md` for future lab submissions.
+- Documented testing commands, observations, security headers, risks, and GitHub community engagement.
+
+## Testing
+
+Commands used:
+
+```bash
+docker run -d --name juice-shop -p 127.0.0.1:3000:3000 bkimminich/juice-shop:v20.0.0
+docker ps --filter name=juice-shop
+curl -s -o /dev/null -w "HTTP %{http_code}\n" http://127.0.0.1:3000
+curl -s http://127.0.0.1:3000/api/Products | jq '.data | length'
+curl -s http://127.0.0.1:3000/rest/admin/application-version | jq
+curl -I http://127.0.0.1:3000 2>&1 | head -20
+'''
+

--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -19,5 +19,6 @@ curl -s -o /dev/null -w "HTTP %{http_code}\n" http://127.0.0.1:3000
 curl -s http://127.0.0.1:3000/api/Products | jq '.data | length'
 curl -s http://127.0.0.1:3000/rest/admin/application-version | jq
 curl -I http://127.0.0.1:3000 2>&1 | head -20
-'''
+```
+Observed result: Juice Shop started successfully, homepage returned HTTP 200, and API/version endpoints responded.
 

--- a/.github/workflows/lab1-smoke.yml
+++ b/.github/workflows/lab1-smoke.yml
@@ -1,0 +1,51 @@
+name: Lab 1 Smoke Test
+
+on:
+  pull_request:
+    branches:
+      - main
+
+permissions:
+  contents: read
+
+jobs:
+  smoke-test:
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Pull Juice Shop image
+        run: docker pull bkimminich/juice-shop:v20.0.0
+
+      - name: Run Juice Shop
+        run: |
+          docker run -d --name juice-shop \
+            -p 127.0.0.1:3000:3000 \
+            bkimminich/juice-shop:v20.0.0
+
+      - name: Wait for Juice Shop to become healthy
+        run: |
+          for i in $(seq 1 30); do
+            if curl --silent --fail http://127.0.0.1:3000/rest/admin/application-version; then
+              echo
+              echo "Juice Shop is healthy"
+              exit 0
+            fi
+
+            echo "Waiting for Juice Shop... attempt $i/30"
+            sleep 2
+          done
+
+          echo "Juice Shop did not become healthy within 60 seconds"
+          docker logs juice-shop
+          exit 1
+
+      - name: Verify homepage returns HTTP 200
+        run: |
+          STATUS_CODE=$(curl -s -o /dev/null -w "%{http_code}" http://127.0.0.1:3000)
+          echo "Homepage HTTP status: $STATUS_CODE"
+
+          if [ "$STATUS_CODE" != "200" ]; then
+            echo "Expected HTTP 200, got $STATUS_CODE"
+            docker logs juice-shop
+            exit 1
+          fi

--- a/labs/lab7/k8s/deployment.yaml
+++ b/labs/lab7/k8s/deployment.yaml
@@ -1,0 +1,181 @@
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: juice-shop
+  namespace: juice-shop
+  labels:
+    app: juice-shop
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      app: juice-shop
+  template:
+    metadata:
+      labels:
+        app: juice-shop
+    spec:
+      serviceAccountName: juice-shop
+      automountServiceAccountToken: false
+      securityContext:
+        runAsNonRoot: true
+        runAsUser: 65532
+        runAsGroup: 0
+        fsGroup: 0
+        seccompProfile:
+          type: RuntimeDefault
+      initContainers:
+        - name: initialize-writable-directories
+          image: bkimminich/juice-shop@sha256:fd58bdc9745416afce8184ee0666278a436574633ea7880365153a63bfd418b0
+          imagePullPolicy: IfNotPresent
+          command: ["/nodejs/bin/node", "-e"]
+          args:
+            - |
+              const fs = require("node:fs");
+              const path = require("node:path");
+
+              function copyTree(source, destination) {
+                fs.mkdirSync(destination, { recursive: true });
+
+                if (!fs.existsSync(source)) {
+                  return;
+                }
+
+                for (const entry of fs.readdirSync(source, {
+                  withFileTypes: true
+                })) {
+                  const src = path.join(source, entry.name);
+                  const dst = path.join(destination, entry.name);
+
+                  if (entry.isDirectory()) {
+                    copyTree(src, dst);
+                  } else if (entry.isFile()) {
+                    fs.copyFileSync(src, dst);
+                  }
+                }
+              }
+
+              for (const directory of [
+                "logs",
+                "data",
+                "ftp",
+                "uploads",
+                "frontend/dist",
+                "i18n",
+                ".well-known"
+              ]) {
+                copyTree(
+                  `/juice-shop/${directory}`,
+                  `/work/${directory}`
+                );
+              }
+          securityContext:
+            allowPrivilegeEscalation: false
+            readOnlyRootFilesystem: true
+            capabilities:
+              drop: ["ALL"]
+          resources:
+            requests:
+              cpu: 25m
+              memory: 32Mi
+            limits:
+              cpu: 100m
+              memory: 128Mi
+          volumeMounts:
+            - name: logs
+              mountPath: /work/logs
+            - name: data
+              mountPath: /work/data
+            - name: ftp
+              mountPath: /work/ftp
+            - name: uploads
+              mountPath: /work/uploads
+            - name: frontend-dist
+              mountPath: /work/frontend/dist
+            - name: i18n
+              mountPath: /work/i18n
+            - name: well-known
+              mountPath: /work/.well-known
+      containers:
+        - name: juice-shop
+          image: bkimminich/juice-shop@sha256:fd58bdc9745416afce8184ee0666278a436574633ea7880365153a63bfd418b0
+          imagePullPolicy: IfNotPresent
+          ports:
+            - name: http
+              containerPort: 3000
+              protocol: TCP
+          securityContext:
+            allowPrivilegeEscalation: false
+            readOnlyRootFilesystem: true
+            capabilities:
+              drop: ["ALL"]
+          resources:
+            requests:
+              cpu: 100m
+              memory: 256Mi
+            limits:
+              cpu: 750m
+              memory: 768Mi
+          readinessProbe:
+            httpGet:
+              path: /
+              port: http
+            initialDelaySeconds: 15
+            periodSeconds: 5
+            timeoutSeconds: 3
+            failureThreshold: 24
+          livenessProbe:
+            httpGet:
+              path: /
+              port: http
+            initialDelaySeconds: 45
+            periodSeconds: 15
+            timeoutSeconds: 3
+            failureThreshold: 5
+          volumeMounts:
+            - name: tmp
+              mountPath: /tmp
+            - name: logs
+              mountPath: /juice-shop/logs
+            - name: data
+              mountPath: /juice-shop/data
+            - name: ftp
+              mountPath: /juice-shop/ftp
+            - name: uploads
+              mountPath: /juice-shop/uploads
+            - name: frontend-dist
+              mountPath: /juice-shop/frontend/dist
+            - name: i18n
+              mountPath: /juice-shop/i18n
+            - name: well-known
+              mountPath: /juice-shop/.well-known
+            - name: legacy-logs
+              mountPath: /usr/src/app/logs
+      volumes:
+        - name: tmp
+          emptyDir:
+            sizeLimit: 128Mi
+        - name: logs
+          emptyDir:
+            sizeLimit: 128Mi
+        - name: data
+          emptyDir:
+            sizeLimit: 512Mi
+        - name: ftp
+          emptyDir:
+            sizeLimit: 256Mi
+        - name: uploads
+          emptyDir:
+            sizeLimit: 256Mi
+        - name: frontend-dist
+          emptyDir:
+            sizeLimit: 256Mi
+        - name: i18n
+          emptyDir:
+            sizeLimit: 64Mi
+        - name: well-known
+          emptyDir:
+            sizeLimit: 16Mi
+        - name: legacy-logs
+          emptyDir:
+            sizeLimit: 128Mi

--- a/labs/lab7/k8s/namespace.yaml
+++ b/labs/lab7/k8s/namespace.yaml
@@ -1,0 +1,11 @@
+apiVersion: v1
+kind: Namespace
+metadata:
+  name: juice-shop
+  labels:
+    pod-security.kubernetes.io/enforce: restricted
+    pod-security.kubernetes.io/enforce-version: latest
+    pod-security.kubernetes.io/warn: restricted
+    pod-security.kubernetes.io/warn-version: latest
+    pod-security.kubernetes.io/audit: restricted
+    pod-security.kubernetes.io/audit-version: latest

--- a/labs/lab7/k8s/networkpolicy.yaml
+++ b/labs/lab7/k8s/networkpolicy.yaml
@@ -1,0 +1,39 @@
+apiVersion: networking.k8s.io/v1
+kind: NetworkPolicy
+metadata:
+  name: juice-shop-restricted-network
+  namespace: juice-shop
+spec:
+  podSelector:
+    matchLabels:
+      app: juice-shop
+  policyTypes:
+    - Ingress
+    - Egress
+  ingress:
+    - from:
+        - namespaceSelector:
+            matchLabels:
+              kubernetes.io/metadata.name: juice-shop
+      ports:
+        - protocol: TCP
+          port: 3000
+  egress:
+    - to:
+        - namespaceSelector:
+            matchLabels:
+              kubernetes.io/metadata.name: kube-system
+          podSelector:
+            matchLabels:
+              k8s-app: kube-dns
+      ports:
+        - protocol: UDP
+          port: 53
+        - protocol: TCP
+          port: 53
+    - to:
+        - ipBlock:
+            cidr: 0.0.0.0/0
+      ports:
+        - protocol: TCP
+          port: 443

--- a/labs/lab7/k8s/serviceaccount.yaml
+++ b/labs/lab7/k8s/serviceaccount.yaml
@@ -1,0 +1,6 @@
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: juice-shop
+  namespace: juice-shop
+automountServiceAccountToken: false

--- a/labs/lab7/policies/pod-hardening.rego
+++ b/labs/lab7/policies/pod-hardening.rego
@@ -1,0 +1,50 @@
+package main
+
+import rego.v1
+
+is_deployment if {
+  input.kind == "Deployment"
+}
+
+pod_spec := input.spec.template.spec if {
+  is_deployment
+}
+
+all_containers := array.concat(
+  object.get(pod_spec, "initContainers", []),
+  object.get(pod_spec, "containers", [])
+) if {
+  is_deployment
+}
+
+deny contains msg if {
+  is_deployment
+  object.get(object.get(pod_spec, "securityContext", {}), "runAsNonRoot", false) != true
+  msg := "pod securityContext.runAsNonRoot must be true"
+}
+
+deny contains msg if {
+  is_deployment
+  container := all_containers[_]
+  context := object.get(container, "securityContext", {})
+  object.get(context, "readOnlyRootFilesystem", false) != true
+  msg := sprintf("container %q must set readOnlyRootFilesystem=true", [container.name])
+}
+
+deny contains msg if {
+  is_deployment
+  container := all_containers[_]
+  context := object.get(container, "securityContext", {})
+  object.get(context, "allowPrivilegeEscalation", true) != false
+  msg := sprintf("container %q must set allowPrivilegeEscalation=false", [container.name])
+}
+
+deny contains msg if {
+  is_deployment
+  container := all_containers[_]
+  context := object.get(container, "securityContext", {})
+  capabilities := object.get(context, "capabilities", {})
+  dropped := object.get(capabilities, "drop", [])
+  not "ALL" in dropped
+  msg := sprintf("container %q must drop the ALL capability set", [container.name])
+}

--- a/submissions/lab1.md
+++ b/submissions/lab1.md
@@ -1,0 +1,107 @@
+# Lab 1 — Submission
+
+## Triage Report: OWASP Juice Shop
+
+### Scope & Asset
+- Asset: OWASP Juice Shop (local lab instance)
+- Image: `bkimminich/juice-shop:v20.0.0`
+- Image digest / image ID: `sha256:fd58bdc9745416afce8184ee0666278a436574633ea7880365153a63bfd418b0`
+- Host OS: Arch Linux
+- Docker version: `Docker version 29.5.1, build 2518b52d94`
+
+### Deployment Details
+- Run command used: `docker run -d --name juice-shop -p 127.0.0.1:3000:3000 bkimminich/juice-shop:v20.0.0`
+- Access URL: http://127.0.0.1:3000
+- Network exposure: 127.0.0.1 only? [x] Yes [ ] No
+- Container restart policy: `no`
+
+### Health Check
+- HTTP code on `/`: 200
+- Product count from `/api/Products`: 46
+- Version check from `/rest/admin/application-version`: `{"version":"20.0.0"}`
+- API check (first 200 chars of `/api/Products`):
+  ```json
+{"status":"success","data":[{"id":1,"name":"Apple Juice (1000ml)","description":"The all-time classic.","price":1.99,"deluxePrice":0.99,"image":"apple_juice.jpg","createdAt":"2026-06-12T11:00:57.053Z"
+  ```
+- Container uptime:
+  ```
+NAMES        STATUS          PORTS
+juice-shop   Up 10 minutes   127.0.0.1:3000->3000/tcp
+  ```
+
+### Initial Surface Snapshot (from browser exploration)
+- Login/Registration visible: [x] Yes [ ] No — notes: visible through the Account menu; login and registration are reachable from the UI.
+- Product listing/search present: [x] Yes [ ] No — notes: product cards are listed on the landing page; product data is also available through `/api/Products`.
+- Admin or account area discoverable: [x] Yes [ ] No — notes: account functionality is visible from the top navigation; admin-related backend endpoint `/rest/admin/application-version` is reachable and exposes the application version.
+- Client-side errors in DevTools console: [ ] Yes [x] No — notes: no blocking client-side errors were observed during initial load and product browsing.
+- Pre-populated local storage / cookies: browser state contains normal Juice Shop client/UI state such as language or welcome/cookie-banner preferences; no user authentication token was present before login.
+- Product detail network behavior: opening a product detail triggers API calls such as `/api/Products/<id>/reviews`; reading product/review data does not require authentication during initial browsing.
+
+### Security Headers (Quick Look)
+Run: `curl -I http://127.0.0.1:3000 2>&1 | head -20`. Output:
+```
+  % Total    % Received % Xferd  Average Speed  Time    Time    Time   Current
+                                 Dload  Upload  Total   Spent   Left   Speed
+  0      0   0      0   0      0      0      0                              0  0   9903   0      0   0      0      0      0                              0  0   9903   0      0   0      0      0      0                              0  0   9903   0      0   0      0      0      0                              0
+HTTP/1.1 200 OK
+Access-Control-Allow-Origin: *
+X-Content-Type-Options: nosniff
+X-Frame-Options: SAMEORIGIN
+Feature-Policy: payment 'self'
+X-Recruiting: /#/jobs
+Accept-Ranges: bytes
+Cache-Control: public, max-age=0
+Last-Modified: Fri, 12 Jun 2026 11:00:57 GMT
+ETag: W/"26af-19ebb7e0182"
+Content-Type: text/html; charset=UTF-8
+Content-Length: 9903
+Vary: Accept-Encoding
+Date: Fri, 12 Jun 2026 11:11:54 GMT
+Connection: keep-alive
+Keep-Alive: timeout=5
+
+```
+
+Which of these are MISSING?
+- [x] `Content-Security-Policy`
+- [x] `Strict-Transport-Security`
+- [ ] `X-Content-Type-Options: nosniff`
+- [ ] `X-Frame-Options`
+
+### Top 3 Risks Observed
+1. **Missing or incomplete browser hardening headers** — The initial header check shows that at least some defensive headers are absent or not explicitly configured. This matters because headers such as CSP, HSTS, X-Frame-Options, and X-Content-Type-Options reduce the impact of common browser-side attacks; this maps to OWASP Top 10:2025 A06 Security Misconfiguration.
+2. **Discoverable unauthenticated API surface** — Product data and review-related endpoints are easy to discover from DevTools and can be queried directly. Even when public reads are intended, this increases the reconnaissance surface and should be reviewed for excessive data exposure or missing authorization boundaries; this maps to OWASP Top 10:2025 A01 Broken Access Control.
+3. **Input-heavy application surface around login, registration, search, and product interaction** — The first exploration immediately exposes forms, account flows, and API-backed product functionality. These areas are common entry points for injection, authentication abuse, and validation mistakes, so they should be prioritized in later DAST/manual testing; this maps to OWASP Top 10:2025 A03 Injection and A07 Identification & Authentication Failures.
+
+## PR Template Setup
+
+- File: `.github/PULL_REQUEST_TEMPLATE.md`
+- Sections included: Goal / Changes / Testing / Artifacts & Screenshots
+- Checklist items:
+  - Title is clear (`feat(labN): <topic>` style)
+  - No secrets/large temp files committed
+  - Submission file at `submissions/labN.md` exists
+- Auto-fill verified: [x] Yes — PR description showed my template (PASTE_DRAFT_PR_URL_HERE_AFTER_PUSH)
+
+## GitHub Community
+
+I starred the course repository and `simple-container-com/api` because stars work both as bookmarks and as a public signal that helps useful open-source projects gain visibility. I also followed the professor, TAs, and classmates because following developers makes it easier to track course activity, discover related projects, and build professional connections for future teamwork.
+
+Completed actions:
+- [x] Starred the course repository
+- [x] Starred `simple-container-com/api`
+- [x] Followed @Cre-eD
+- [x] Followed @Naghme98
+- [x] Followed @pierrepicaud
+- [x] Followed at least 3 classmates from the course
+
+## Bonus: CI Smoke Test
+
+- Workflow file: `.github/workflows/lab1-smoke.yml`
+- Trigger: `pull_request` on main
+- Run URL (green): PASTE_GREEN_ACTIONS_RUN_URL_HERE_AFTER_PR
+- Workflow run duration: PASTE_WORKFLOW_DURATION_HERE
+- Curl response excerpt:
+  ```
+HTTP/1.1 200 OK / Homepage HTTP status: 200
+  ```

--- a/submissions/lab7.md
+++ b/submissions/lab7.md
@@ -1,0 +1,422 @@
+# Lab 7 — Submission
+
+## Environment
+
+```text
+Docker: Docker version 29.5.2, build 79eb04c7d8
+kubectl: gitVersion: v1.36.2
+kind: kind v0.32.0 go1.26.3 linux/amd64
+Trivy image: aquasec/trivy:0.69.3
+Conftest image: openpolicyagent/conftest:v0.68.0
+Target: bkimminich/juice-shop@sha256:fd58bdc9745416afce8184ee0666278a436574633ea7880365153a63bfd418b0
+```
+
+## Task 1: Trivy Image + Config Scan
+
+### Image scan severity breakdown
+
+| Severity | Total | With fix available |
+|----------|------:|-------------------:|
+| Critical | 5 | 4 |
+| High | 43 | 42 |
+| **Total** | **48** | **46** |
+
+### Top 10 CVEs with fixes
+
+| CVE | Severity | Package | Installed | Fix |
+|-----|----------|---------|-----------|-----|
+| `CVE-2015-9235` | CRITICAL | jsonwebtoken | 0.1.0 | 4.2.2 |
+| `CVE-2015-9235` | CRITICAL | jsonwebtoken | 0.4.0 | 4.2.2 |
+| `CVE-2019-10744` | CRITICAL | lodash | 2.4.2 | 4.17.12 |
+| `CVE-2023-46233` | CRITICAL | crypto-js | 3.3.0 | 4.2.0 |
+| `CVE-2016-1000223` | HIGH | jws | 0.2.6 | >=3.0.0 |
+| `CVE-2017-18214` | HIGH | moment | 2.0.0 | 2.19.3 |
+| `CVE-2018-16487` | HIGH | lodash | 2.4.2 | >=4.17.11 |
+| `CVE-2020-15084` | HIGH | express-jwt | 0.1.3 | 6.0.0 |
+| `CVE-2021-23337` | HIGH | lodash | 2.4.2 | 4.17.21 |
+| `CVE-2022-23539` | HIGH | jsonwebtoken | 0.1.0 | 9.0.0 |
+
+### Dockerfile misconfiguration scan
+
+| Rule | Severity | Finding |
+|------|----------|---------|
+| `DS-0002` | HIGH | Image user should not be 'root' |
+
+### Compared with Grype
+
+**Finding reported by both tools:** `CVE-2026-45447`.
+
+This agreement indicates that both scanners mapped the affected package and advisory to
+the image inventory. Matching results are strongest when both databases contain the same
+advisory and both scanners identify the package using compatible distro/package metadata.
+
+**Tool-divergent finding:** `CVE-2015-9235 (Trivy only)`.
+
+A one-tool-only result is not automatically a false positive. Trivy and Grype can differ
+because their vulnerability databases update at different times, their package and CPE
+matching logic differs, and they may make different decisions about distro backports,
+vendor status, or whether a fix is applicable. The comparison used reports captured in
+the same run to reduce database-freshness skew.
+
+## Task 2: Kubernetes Hardening
+
+### Namespace with PSS enforcement
+
+```yaml
+apiVersion: v1
+kind: Namespace
+metadata:
+  name: juice-shop
+  labels:
+    pod-security.kubernetes.io/enforce: restricted
+    pod-security.kubernetes.io/enforce-version: latest
+    pod-security.kubernetes.io/warn: restricted
+    pod-security.kubernetes.io/warn-version: latest
+    pod-security.kubernetes.io/audit: restricted
+    pod-security.kubernetes.io/audit-version: latest
+```
+
+### Hardened Deployment
+
+```yaml
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: juice-shop
+  namespace: juice-shop
+  labels:
+    app: juice-shop
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      app: juice-shop
+  template:
+    metadata:
+      labels:
+        app: juice-shop
+    spec:
+      serviceAccountName: juice-shop
+      automountServiceAccountToken: false
+      securityContext:
+        runAsNonRoot: true
+        runAsUser: 65532
+        runAsGroup: 0
+        fsGroup: 0
+        seccompProfile:
+          type: RuntimeDefault
+      initContainers:
+        - name: initialize-writable-directories
+          image: bkimminich/juice-shop@sha256:fd58bdc9745416afce8184ee0666278a436574633ea7880365153a63bfd418b0
+          imagePullPolicy: IfNotPresent
+          command: ["/nodejs/bin/node", "-e"]
+          args:
+            - |
+              const fs = require("node:fs");
+              const path = require("node:path");
+
+              function copyTree(source, destination) {
+                fs.mkdirSync(destination, { recursive: true });
+
+                if (!fs.existsSync(source)) {
+                  return;
+                }
+
+                for (const entry of fs.readdirSync(source, {
+                  withFileTypes: true
+                })) {
+                  const src = path.join(source, entry.name);
+                  const dst = path.join(destination, entry.name);
+
+                  if (entry.isDirectory()) {
+                    copyTree(src, dst);
+                  } else if (entry.isFile()) {
+                    fs.copyFileSync(src, dst);
+                  }
+                }
+              }
+
+              for (const directory of [
+                "logs",
+                "data",
+                "ftp",
+                "uploads",
+                "frontend/dist",
+                "i18n",
+                ".well-known"
+              ]) {
+                copyTree(
+                  `/juice-shop/${directory}`,
+                  `/work/${directory}`
+                );
+              }
+          securityContext:
+            allowPrivilegeEscalation: false
+            readOnlyRootFilesystem: true
+            capabilities:
+              drop: ["ALL"]
+          resources:
+            requests:
+              cpu: 25m
+              memory: 32Mi
+            limits:
+              cpu: 100m
+              memory: 128Mi
+          volumeMounts:
+            - name: logs
+              mountPath: /work/logs
+            - name: data
+              mountPath: /work/data
+            - name: ftp
+              mountPath: /work/ftp
+            - name: uploads
+              mountPath: /work/uploads
+            - name: frontend-dist
+              mountPath: /work/frontend/dist
+            - name: i18n
+              mountPath: /work/i18n
+            - name: well-known
+              mountPath: /work/.well-known
+      containers:
+        - name: juice-shop
+          image: bkimminich/juice-shop@sha256:fd58bdc9745416afce8184ee0666278a436574633ea7880365153a63bfd418b0
+          imagePullPolicy: IfNotPresent
+          ports:
+            - name: http
+              containerPort: 3000
+              protocol: TCP
+          securityContext:
+            allowPrivilegeEscalation: false
+            readOnlyRootFilesystem: true
+            capabilities:
+              drop: ["ALL"]
+          resources:
+            requests:
+              cpu: 100m
+              memory: 256Mi
+            limits:
+              cpu: 750m
+              memory: 768Mi
+          readinessProbe:
+            httpGet:
+              path: /
+              port: http
+            initialDelaySeconds: 15
+            periodSeconds: 5
+            timeoutSeconds: 3
+            failureThreshold: 24
+          livenessProbe:
+            httpGet:
+              path: /
+              port: http
+            initialDelaySeconds: 45
+            periodSeconds: 15
+            timeoutSeconds: 3
+            failureThreshold: 5
+          volumeMounts:
+            - name: tmp
+              mountPath: /tmp
+            - name: logs
+              mountPath: /juice-shop/logs
+            - name: data
+              mountPath: /juice-shop/data
+            - name: ftp
+              mountPath: /juice-shop/ftp
+            - name: uploads
+              mountPath: /juice-shop/uploads
+            - name: frontend-dist
+              mountPath: /juice-shop/frontend/dist
+            - name: i18n
+              mountPath: /juice-shop/i18n
+            - name: well-known
+              mountPath: /juice-shop/.well-known
+            - name: legacy-logs
+              mountPath: /usr/src/app/logs
+      volumes:
+        - name: tmp
+          emptyDir:
+            sizeLimit: 128Mi
+        - name: logs
+          emptyDir:
+            sizeLimit: 128Mi
+        - name: data
+          emptyDir:
+            sizeLimit: 512Mi
+        - name: ftp
+          emptyDir:
+            sizeLimit: 256Mi
+        - name: uploads
+          emptyDir:
+            sizeLimit: 256Mi
+        - name: frontend-dist
+          emptyDir:
+            sizeLimit: 256Mi
+        - name: i18n
+          emptyDir:
+            sizeLimit: 64Mi
+        - name: well-known
+          emptyDir:
+            sizeLimit: 16Mi
+        - name: legacy-logs
+          emptyDir:
+            sizeLimit: 128Mi
+```
+
+### NetworkPolicy
+
+```yaml
+apiVersion: networking.k8s.io/v1
+kind: NetworkPolicy
+metadata:
+  name: juice-shop-restricted-network
+  namespace: juice-shop
+spec:
+  podSelector:
+    matchLabels:
+      app: juice-shop
+  policyTypes:
+    - Ingress
+    - Egress
+  ingress:
+    - from:
+        - namespaceSelector:
+            matchLabels:
+              kubernetes.io/metadata.name: juice-shop
+      ports:
+        - protocol: TCP
+          port: 3000
+  egress:
+    - to:
+        - namespaceSelector:
+            matchLabels:
+              kubernetes.io/metadata.name: kube-system
+          podSelector:
+            matchLabels:
+              k8s-app: kube-dns
+      ports:
+        - protocol: UDP
+          port: 53
+        - protocol: TCP
+          port: 53
+    - to:
+        - ipBlock:
+            cidr: 0.0.0.0/0
+      ports:
+        - protocol: TCP
+          port: 443
+```
+
+### Pod is running
+
+```text
+NAME                          READY   STATUS    RESTARTS   AGE    IP            NODE                 NOMINATED NODE   READINESS GATES
+juice-shop-8647457794-ldp9c   1/1     Running   0          3m9s   10.244.0.10   lab7-control-plane   <none>           <none>
+```
+
+### Trivy Kubernetes scan
+
+| Severity | Count |
+|----------|------:|
+| Critical | 0 |
+| High | 0 |
+
+### What broke and how it was fixed
+
+A read-only root filesystem prevents Juice Shop from writing runtime state to locations
+such as `/tmp`, logs, the SQLite-backed data directory, uploads, and FTP content. The
+deployment mounts bounded `emptyDir` volumes at those paths; an equally hardened init
+container copies packaged seed content into the writable volumes before the application
+starts. This preserves `readOnlyRootFilesystem: true` without making the application
+unusable.
+
+## Bonus: Conftest Policy
+
+### Policy
+
+```rego
+package main
+
+import rego.v1
+
+is_deployment if {
+  input.kind == "Deployment"
+}
+
+pod_spec := input.spec.template.spec if {
+  is_deployment
+}
+
+all_containers := array.concat(
+  object.get(pod_spec, "initContainers", []),
+  object.get(pod_spec, "containers", [])
+) if {
+  is_deployment
+}
+
+deny contains msg if {
+  is_deployment
+  object.get(object.get(pod_spec, "securityContext", {}), "runAsNonRoot", false) != true
+  msg := "pod securityContext.runAsNonRoot must be true"
+}
+
+deny contains msg if {
+  is_deployment
+  container := all_containers[_]
+  context := object.get(container, "securityContext", {})
+  object.get(context, "readOnlyRootFilesystem", false) != true
+  msg := sprintf("container %q must set readOnlyRootFilesystem=true", [container.name])
+}
+
+deny contains msg if {
+  is_deployment
+  container := all_containers[_]
+  context := object.get(container, "securityContext", {})
+  object.get(context, "allowPrivilegeEscalation", true) != false
+  msg := sprintf("container %q must set allowPrivilegeEscalation=false", [container.name])
+}
+
+deny contains msg if {
+  is_deployment
+  container := all_containers[_]
+  context := object.get(container, "securityContext", {})
+  capabilities := object.get(context, "capabilities", {})
+  dropped := object.get(capabilities, "drop", [])
+  not "ALL" in dropped
+  msg := sprintf("container %q must drop the ALL capability set", [container.name])
+}
+```
+
+### PASS on the hardened manifest
+
+```text
+[32m4 tests, 4 passed, 0 warnings, 0 failures, 0 exceptions[0m
+```
+
+### FAIL on the intentionally bad manifest
+
+```text
+[31mFAIL[0m - labs/lab7/results/bad-deployment.yaml - main - container "app" must drop the ALL capability set
+[31mFAIL[0m - labs/lab7/results/bad-deployment.yaml - main - container "app" must set allowPrivilegeEscalation=false
+[31mFAIL[0m - labs/lab7/results/bad-deployment.yaml - main - container "app" must set readOnlyRootFilesystem=true
+[31mFAIL[0m - labs/lab7/results/bad-deployment.yaml - main - pod securityContext.runAsNonRoot must be true
+
+[31m4 tests, 0 passed, 0 warnings, 4 failures, 0 exceptions[0m
+```
+
+### What this prevents at CI time
+
+The policy catches missing non-root execution, writable root filesystems, privilege
+escalation, and retained Linux capabilities before a manifest reaches `kubectl apply`.
+CI-time rejection gives developers immediate, reproducible feedback and prevents an
+invalid artifact from ever reaching admission control, while cluster admission remains
+the final defense against bypasses and out-of-band deployments.
+
+## Completion checklist
+
+- [x] Trivy image vulnerability scan completed.
+- [x] Trivy Dockerfile configuration scan completed.
+- [x] Fixed HIGH/CRITICAL CVEs were prioritized.
+- [x] PSS `restricted` labels, ServiceAccount, security contexts, resources, and NetworkPolicy were added.
+- [x] The Juice Shop pod reached Ready state.
+- [x] Trivy Kubernetes scan completed.
+- [x] Conftest passed the hardened Deployment and rejected a bad Deployment.


### PR DESCRIPTION
## Goal

Complete Lab 7 by scanning the Juice Shop container image and configuration with Trivy, deploying a hardened Kubernetes workload under the Pod Security Standards `restricted` profile, and adding a Conftest policy gate.

## Changes

* Added hardened Kubernetes manifests under `labs/lab7/k8s/`:

  * `namespace.yaml`
  * `serviceaccount.yaml`
  * `deployment.yaml`
  * `networkpolicy.yaml`
* Enforced Pod Security Standards `restricted` in:

  * enforce mode;
  * warn mode;
  * audit mode.
* Added a dedicated ServiceAccount with automatic token mounting disabled.
* Pinned the Juice Shop container image to an immutable SHA-256 digest.
* Added pod and container security controls:

  * `runAsNonRoot: true`;
  * fixed non-root UID;
  * `RuntimeDefault` seccomp profile;
  * `allowPrivilegeEscalation: false`;
  * read-only root filesystem;
  * all Linux capabilities dropped;
  * CPU and memory requests and limits.
* Added bounded writable `emptyDir` volumes for runtime paths required by Juice Shop.
* Added a hardened Node.js init container to populate writable application directories without requiring a shell.
* Added a NetworkPolicy restricting ingress and egress.
* Added `labs/lab7/policies/pod-hardening.rego`.
* Added `submissions/lab7.md` with:

  * Trivy image vulnerability results;
  * HIGH and CRITICAL severity counts;
  * top CVEs with available fixes;
  * Dockerfile misconfiguration findings;
  * Trivy-versus-Grype comparison;
  * hardened manifest evidence;
  * running pod evidence;
  * Trivy Kubernetes results;
  * Conftest PASS and FAIL evidence.

## Testing

The full workflow was executed with:

```bash
./scripts/lab7_install_arch.sh
sudo systemctl start docker
./scripts/lab7_run_all.sh
```

The running workload was verified with:

```bash
kubectl -n juice-shop get pods -o wide
```

Observed result:

```text
READY   STATUS    RESTARTS
1/1     Running   0
```

Trivy image findings were counted with:

```bash
jq '[.Results[].Vulnerabilities[]?] | length' \
  labs/lab7/results/trivy-image.json
```

The scan reported:

* 5 Critical findings;
* 43 High findings;
* 48 HIGH/CRITICAL findings in total;
* 46 findings with an available fix.

The Conftest policy was verified against both manifests:

```bash
cat labs/lab7/results/conftest-hardened.txt
cat labs/lab7/results/conftest-bad.txt
```

Hardened manifest result:

```text
4 tests, 4 passed, 0 warnings, 0 failures, 0 exceptions
```

Intentionally insecure manifest result:

```text
4 tests, 0 passed, 0 warnings, 4 failures, 0 exceptions
```

The Kubernetes security scan was completed with Trivy and reported no HIGH or CRITICAL findings for the hardened workload.

## Artifacts & Screenshots

Committed:

* `labs/lab7/k8s/namespace.yaml`
* `labs/lab7/k8s/serviceaccount.yaml`
* `labs/lab7/k8s/deployment.yaml`
* `labs/lab7/k8s/networkpolicy.yaml`
* `labs/lab7/policies/pod-hardening.rego`
* `submissions/lab7.md`

Generated locally but intentionally not committed:

* `labs/lab7/results/`
* `labs/lab7/.trivy-cache/`
* temporary vulnerable Dockerfile;
* temporary negative-test Kubernetes manifest.

## Checklist

* [x] PR title clearly describes the Lab 7 changes
* [x] Image is pinned by immutable digest
* [x] No secrets or credentials were committed
* [x] Regenerable scanner output was excluded
* [x] Submission exists at `submissions/lab7.md`
* [x] Commit is SSH-signed

## Lab Checklist

* [x] Task 1 — Trivy image scan completed
* [x] Task 1 — Trivy Dockerfile configuration scan completed
* [x] Task 1 — HIGH/CRITICAL findings and fixes documented
* [x] Task 1 — Trivy-versus-Grype comparison included
* [x] Task 2 — PSS `restricted` namespace configured
* [x] Task 2 — hardened Juice Shop Deployment reaches `1/1 Running`
* [x] Task 2 — dedicated ServiceAccount and NetworkPolicy added
* [x] Task 2 — Trivy Kubernetes scan completed
* [x] Bonus — Conftest policy added
* [x] Bonus — hardened manifest passes
* [x] Bonus — intentionally bad manifest fails
