### PR TITLE
Feature/lab11

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -1,0 +1,24 @@
+## Goal
+<!-- 1 sentence: what this PR delivers -->
+
+## Changes
+<!-- Bullet list of artifacts added/modified -->
+- 
+- 
+- 
+
+## Testing
+<!-- Commands + observed output -->
+```bash
+# <command>
+# <output>
+```
+
+## Artifacts & Screenshots
+<!-- Links to files in this PR, image embeds where useful -->
+-
+
+## Checklist
+- [ ] Title is clear (`feat(labN): <topic>` style)
+- [ ] No secrets/large temp files committed
+- [ ] Submission file at `submissions/labN.md` exists

--- a/.github/workflows/lab1-smoke.yml
+++ b/.github/workflows/lab1-smoke.yml
@@ -1,0 +1,49 @@
+name: Lab 1 — Juice Shop Smoke Test
+
+on:
+  pull_request:
+    branches: [main]
+
+permissions:
+  contents: read
+
+jobs:
+  smoke-test:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
+
+      - name: Pull and run Juice Shop
+        run: |
+          docker run -d --name juice-shop \
+            -p 127.0.0.1:3000:3000 \
+            bkimminich/juice-shop:v20.0.0
+
+      - name: Wait for Juice Shop to be healthy
+        run: |
+          echo "Waiting for Juice Shop to start..."
+          for i in $(seq 1 30); do
+            if curl --silent --fail http://127.0.0.1:3000/rest/admin/application-version >/dev/null; then
+              echo "Juice Shop is up!"
+              exit 0
+            fi
+            echo "Attempt $i/30 — not ready yet, sleeping 2s..."
+            sleep 2
+          done
+          echo "Juice Shop failed to start within 60s"
+          docker logs juice-shop
+          exit 1
+
+      - name: Verify homepage returns HTTP 200
+        run: |
+          curl -I -s http://127.0.0.1:3000 | head -5
+          curl -s -o /dev/null -w "HTTP Status: %{http_code}\n" http://127.0.0.1:3000
+
+      - name: Verify product API
+        run: |
+          curl -s http://127.0.0.1:3000/api/Products | jq '.data | length'
+
+      - name: Verify version endpoint
+        run: |
+          curl -s http://127.0.0.1:3000/rest/admin/application-version | jq

--- a/labs/lab11/reverse-proxy/nginx.conf
+++ b/labs/lab11/reverse-proxy/nginx.conf
@@ -29,7 +29,9 @@ http {
   # Rate limit zone for login
   # ~10 req/min per IP, burst of 5
   limit_req_zone $binary_remote_addr zone=login:10m rate=10r/m;
+  limit_conn_zone $binary_remote_addr zone=conn:10m;
   limit_req_status 429;
+  limit_conn_status 429;
 
   map $http_upgrade $connection_upgrade { default upgrade; '' close; }
 
@@ -60,36 +62,46 @@ http {
 
   # HTTP server (redirect to HTTPS)
   server {
-    listen 8080;
-    listen [::]:8080;
+    listen 80;
+    listen [::]:80;
     server_name _;
+
+    limit_conn conn 50;
 
     # Core headers (also on redirects)
     add_header X-Frame-Options "DENY" always;
     add_header X-Content-Type-Options "nosniff" always;
     add_header Referrer-Policy "strict-origin-when-cross-origin" always;
-    add_header Permissions-Policy "camera=(), geolocation=(), microphone=()" always;
+    add_header Permissions-Policy "camera=(), microphone=(), geolocation=()" always;
     add_header Cross-Origin-Opener-Policy "same-origin" always;
     add_header Cross-Origin-Resource-Policy "same-origin" always;
-    add_header Content-Security-Policy-Report-Only "default-src 'self'; img-src 'self' data:; script-src 'self' 'unsafe-inline' 'unsafe-eval'; style-src 'self' 'unsafe-inline'" always;
+    add_header Content-Security-Policy-Report-Only "default-src 'self'; base-uri 'self'; object-src 'none'; frame-ancestors 'none'; form-action 'self'; script-src 'self'; style-src 'self'; img-src 'self' data:; connect-src 'self' wss:; upgrade-insecure-requests" always;
 
-    return 308 https://$host:8443$request_uri;
+    return 308 https://$host$request_uri;
   }
 
   # HTTPS server
   server {
-    listen 8443 ssl;
-    listen [::]:8443 ssl;
+    listen 443 ssl;
+    listen [::]:443 ssl;
     http2 on;
     server_name _;
 
     ssl_certificate     /etc/nginx/certs/localhost.crt;
     ssl_certificate_key /etc/nginx/certs/localhost.key;
-    ssl_session_timeout 10m;
-    ssl_session_cache   shared:SSL:10m;
-    ssl_protocols TLSv1.2 TLSv1.3;
-    ssl_ciphers "TLS_AES_256_GCM_SHA384:TLS_CHACHA20_POLY1305_SHA256:TLS_AES_128_GCM_SHA256:EECDH+AESGCM:EDH+AESGCM";
-    ssl_prefer_server_ciphers on;
+
+    # Modern TLS profile: TLS 1.3 only. In Nginx, TLS 1.3 suites are
+    # configured with OpenSSL's Ciphersuites command; ssl_ciphers controls
+    # TLS 1.2 and older and is deliberately left at a safe non-empty value.
+    ssl_protocols TLSv1.3;
+    ssl_ciphers HIGH:!aNULL:!MD5;
+    ssl_conf_command Ciphersuites TLS_AES_128_GCM_SHA256:TLS_AES_256_GCM_SHA384:TLS_CHACHA20_POLY1305_SHA256;
+    ssl_prefer_server_ciphers off;
+    ssl_ecdh_curve X25519:secp384r1;
+    ssl_session_cache shared:SSL:10m;
+    ssl_session_timeout 1d;
+    ssl_session_tickets off;
+    ssl_early_data off;
     ssl_stapling off;
     # If using a publicly-trusted certificate, you may enable OCSP stapling:
     # ssl_stapling on;
@@ -103,16 +115,19 @@ http {
     client_header_timeout 10s;
     keepalive_timeout 10s;
     send_timeout 10s;
+    reset_timedout_connection on;
+
+    limit_conn conn 50;
 
     # Security headers (include HSTS here only)
-    add_header Strict-Transport-Security "max-age=31536000; includeSubDomains; preload" always;
+    add_header Strict-Transport-Security "max-age=63072000; includeSubDomains; preload" always;
     add_header X-Frame-Options "DENY" always;
     add_header X-Content-Type-Options "nosniff" always;
     add_header Referrer-Policy "strict-origin-when-cross-origin" always;
-    add_header Permissions-Policy "camera=(), geolocation=(), microphone=()" always;
+    add_header Permissions-Policy "camera=(), microphone=(), geolocation=()" always;
     add_header Cross-Origin-Opener-Policy "same-origin" always;
     add_header Cross-Origin-Resource-Policy "same-origin" always;
-    add_header Content-Security-Policy-Report-Only "default-src 'self'; img-src 'self' data:; script-src 'self' 'unsafe-inline' 'unsafe-eval'; style-src 'self' 'unsafe-inline'" always;
+    add_header Content-Security-Policy-Report-Only "default-src 'self'; base-uri 'self'; object-src 'none'; frame-ancestors 'none'; form-action 'self'; script-src 'self'; style-src 'self'; img-src 'self' data:; connect-src 'self' wss:; upgrade-insecure-requests" always;
 
     location = /rest/user/login {
       limit_req zone=login burst=5 nodelay;

--- a/labs/lab11/waf/Dockerfile
+++ b/labs/lab11/waf/Dockerfile
@@ -1,0 +1,8 @@
+FROM owasp/modsecurity-crs:4.25.1-nginx-alpine-lts
+
+USER root
+
+RUN mkdir -p /var/log/modsec \
+    && chown nginx:nginx /var/log/modsec
+
+RUN sed -i '/^proxy_ssl_certificate /d; /^proxy_ssl_certificate_key /d' /etc/nginx/templates/includes/proxy_backend_ssl.conf.template

--- a/labs/lab11/waf/docker-compose.override.yml
+++ b/labs/lab11/waf/docker-compose.override.yml
@@ -1,0 +1,46 @@
+version: "3.7"
+
+services:
+  waf:
+    build:
+      context: .
+      dockerfile: waf/Dockerfile
+    image: devsecops-lab11-waf:crs-4.25.1
+    restart: unless-stopped
+    depends_on:
+      - nginx
+    ports:
+      - "8443:8443"
+    environment:
+      BACKEND: https://nginx:443
+      PROXY_SSL: "on"
+      PROXY_SSL_VERIFY: "off"
+      PROXY_SSL_PROTOCOLS: TLSv1.3
+      SERVER_NAME: localhost
+      SERVER_TOKENS: "off"
+      PORT: "8080"
+      SSL_PORT: "8443"
+      SSL_PROTOCOLS: TLSv1.3
+      SSL_OCSP_STAPLING: "off"
+      NGINX_ALWAYS_TLS_REDIRECT: "on"
+      NGINX_X_FORWARDED_PORT: "8443"
+      NGINX_X_FORWARDED_PROTO: https
+      MODSEC_RULE_ENGINE: "On"
+      MODSEC_AUDIT_ENGINE: "On"
+      MODSEC_AUDIT_LOG: /var/log/modsec/audit.log
+      MODSEC_AUDIT_LOG_FORMAT: Native
+      MODSEC_AUDIT_LOG_PARTS: ABIJDEFHZ
+      MODSEC_AUDIT_LOG_TYPE: Serial
+      MODSEC_REQ_BODY_ACCESS: "On"
+      BLOCKING_PARANOIA: "1"
+      DETECTION_PARANOIA: "1"
+      ANOMALY_INBOUND: "5"
+      ANOMALY_OUTBOUND: "4"
+      REPORTING_LEVEL: "2"
+    volumes:
+      - ./reverse-proxy/certs/localhost.crt:/etc/nginx/conf/server.crt:ro
+      - ./reverse-proxy/certs/localhost.key:/etc/nginx/conf/server.key:ro
+      - waf-audit:/var/log/modsec
+
+volumes:
+  waf-audit:

--- a/submissions/lab1.md
+++ b/submissions/lab1.md
@@ -78,7 +78,7 @@ Which of these are MISSING? (cross-reference Lecture 1 OWASP Top 10:2025 — A06
 - [x] Following Professor [@Cre-eD](https://github.com/Cre-eD)
 - [x] Following TA [@Naghme98](https://github.com/Naghme98)
 - [x] Following TA [@pierrepicaud](https://github.com/pierrepicaud)
-- [x] Following 3+ classmates: `<, @username2, @username3>`
+- [x] Following 3+ classmates
 
 ### Why Stars Matter in Open Source
 Stars are the currency of attention in the open-source ecosystem. A repository with 1000+ stars attracts more contributors and sponsors than an equivalent one with 10 stars.

--- a/submissions/lab1.md
+++ b/submissions/lab1.md
@@ -1,0 +1,100 @@
+# Lab 1 — Submission
+
+## Triage Report: OWASP Juice Shop
+
+### Scope & Asset
+- Asset: OWASP Juice Shop (local lab instance)
+- Image: `bkimminich/juice-shop:v20.0.0`
+- Image digest: `sha256:99779f57113bd47312e8fe7b264ff402ee41da76ddda7f2fc842a92ad51827ce`
+- Host OS: REMnux (Ubuntu 20.04-based)
+- Docker version: `Docker version 26.1.3, build 26.1.3-0ubuntu1~20.04.1`
+
+### Deployment Details
+- Run command used: `docker run -d --name juice-shop -p 127.0.0.1:3000:3000 bkimminich/juice-shop:v20.0.0`
+- Access URL: http://127.0.0.1:3000
+- Network exposure: 127.0.0.1 only? [x] Yes [ ] No
+- Container restart policy: default `no` (no `--restart` flag used)
+
+### Health Check
+- HTTP code on `/`: `200`
+- API check (first 200 chars of `/api/Products`):
+  ```json
+  {"status":"success","data":[{"id":1,"name":"Apple Juice (1000ml)","description":"The all-time classic.","price":1.99,"deluxePrice":0.99,"image":"apple_juice.jpg","createdAt":"2026-06-12T10:31:40.266Z"
+  ```
+- Container uptime: 4bd57343c74b   bkimminich/juice-shop:v20.0.0   "/nodejs/bin/node /j…"   14 minutes ago   Up 14 minutes   127.0.0.1:3000->3000/tcp   juice-shop
+
+### Initial Surface Snapshot (from browser exploration)
+- Login/Registration visible: [x] Yes [ ] No — notes:  Login and Sign Up buttons present
+- Product listing/search present: [x] Yes [ ] No — notes: Product cards displayed on homepage, search field available
+- Admin or account area discoverable: [ ] Yes [x] No — notes: No direct admin link on landing page; authentication required
+- Client-side errors in DevTools console: [ ] Yes [x] No — notes: Console clean, no errors detected
+- Pre-populated local storage / cookies: language (set to 'en'), token (empty until login)
+
+
+### Security Headers (Quick Look)
+HTTP/1.1 200 OK
+Access-Control-Allow-Origin: *
+X-Content-Type-Options: nosniff
+X-Frame-Options: SAMEORIGIN
+Feature-Policy: payment 'self'
+X-Recruiting: /#/jobs
+Accept-Ranges: bytes
+Cache-Control: public, max-age=0
+Last-Modified: Fri, 12 Jun 2026 10:31:40 GMT
+ETag: W/"26af-19ebb633283"
+Content-Type: text/html; charset=UTF-8
+Content-Length: 9903
+Vary: Accept-Encoding
+Date: Fri, 12 Jun 2026 10:34:55 GMT
+Connection: keep-alive
+Keep-Alive: timeout=5
+
+Which of these are MISSING? (cross-reference Lecture 1 OWASP Top 10:2025 — A06)
+- [x] `Content-Security-Policy` - MISSING
+- [x] `Strict-Transport-Security` - MISSING
+- [ ] `X-Content-Type-Options: nosniff`
+- [ ] `X-Frame-Options`
+
+### Top 3 Risks Observed (2-3 sentences each, in your own words)
+1. Broken Access Control (A01) — The API endpoint /api/Products/<id>/reviews returns data without authentication. This allows an unauthenticated attacker to read other users' reviews and potentially exfiltrate data, violating the principle of least privilege.
+2. Cryptographic Failures (A02) — Absence of the HSTS header and operation over HTTP (in local environment) means that in production traffic could be intercepted. If the application transmits credentials or tokens without TLS, this leads to sensitive data exposure.
+3. Security Misconfiguration (A05) — The complete absence of CSP and HSTS indicates a default 'open' configuration. Combined with intentionally vulnerable Juice Shop code, this creates a broad surface for XSS, clickjacking, and MIME-sniffing attacks.
+
+## PR Template Setup
+
+- File: `.github/PULL_REQUEST_TEMPLATE.md`
+- Sections included: Goal / Changes / Testing / Artifacts & Screenshots
+- Checklist items:
+  - Title is clear (`feat(labN): <topic>` style)
+  - No secrets/large temp files committed
+  - Submission file at `submissions/labN.md` exists
+- Auto-fill verified: [x] Yes — PR description showed my template (screenshot or link to draft PR)
+
+## GitHub Community
+
+### Actions Completed
+- [x] Starred course repository
+- [x] Starred [simple-container-com/api](https://github.com/simple-container-com/api)
+- [x] Following Professor [@Cre-eD](https://github.com/Cre-eD)
+- [x] Following TA [@Naghme98](https://github.com/Naghme98)
+- [x] Following TA [@pierrepicaud](https://github.com/pierrepicaud)
+- [x] Following 3+ classmates: `<, @username2, @username3>`
+
+### Why Stars Matter in Open Source
+Stars are the currency of attention in the open-source ecosystem. A repository with 1000+ stars attracts more contributors and sponsors than an equivalent one with 10 stars.
+
+## Bonus: CI Smoke Test
+
+- Workflow file: `.github/workflows/lab1-smoke.yml`
+- Trigger: `pull_request` on main
+- Run URL (must be green): https://github.com/raaller/DevSecOps-Intro/actions/runs/27413678469
+- Workflow run duration: 27s
+- Curl response excerpt:
+  ```
+  HTTP/1.1 200 OK
+  Access-Control-Allow-Origin: *
+  X-Content-Type-Options: nosniff
+  X-Frame-Options: SAMEORIGIN
+  Feature-Policy: payment 'self'
+  HTTP Status: 200
+  ```

--- a/submissions/lab11.md
+++ b/submissions/lab11.md
@@ -1,0 +1,205 @@
+# Lab 11 — BONUS — Submission
+
+Runtime evidence was collected automatically on **2026-07-17 14:27:00 UTC** by `labs/lab11/run-and-collect.sh`. The script aborts instead of rendering this report if a required control fails.
+
+## Task 1: TLS + Security Headers
+
+### nginx.conf — redirect, TLS, and response-header sections
+
+```nginx
+# Port 80
+return 308 https://$host$request_uri;
+
+# Port 443
+listen 443 ssl;
+listen [::]:443 ssl;
+http2 on;
+ssl_certificate     /etc/nginx/certs/localhost.crt;
+ssl_certificate_key /etc/nginx/certs/localhost.key;
+ssl_protocols TLSv1.3;
+ssl_ciphers HIGH:!aNULL:!MD5;
+ssl_conf_command Ciphersuites TLS_AES_128_GCM_SHA256:TLS_AES_256_GCM_SHA384:TLS_CHACHA20_POLY1305_SHA256;
+ssl_prefer_server_ciphers off;
+ssl_ecdh_curve X25519:secp384r1;
+ssl_session_cache shared:SSL:10m;
+ssl_session_timeout 1d;
+ssl_session_tickets off;
+ssl_early_data off;
+add_header Strict-Transport-Security "max-age=63072000; includeSubDomains; preload" always;
+add_header X-Frame-Options "DENY" always;
+add_header X-Content-Type-Options "nosniff" always;
+add_header Referrer-Policy "strict-origin-when-cross-origin" always;
+add_header Permissions-Policy "camera=(), microphone=(), geolocation=()" always;
+add_header Cross-Origin-Opener-Policy "same-origin" always;
+add_header Cross-Origin-Resource-Policy "same-origin" always;
+add_header Content-Security-Policy-Report-Only "default-src 'self'; base-uri 'self'; object-src 'none'; frame-ancestors 'none'; form-action 'self'; script-src 'self'; style-src 'self'; img-src 'self' data:; connect-src 'self' wss:; upgrade-insecure-requests" always;
+```
+
+Nginx uses `ssl_conf_command Ciphersuites` for TLS 1.3 suites because `ssl_ciphers` configures TLS 1.2 and older suites. TLS 1.2 is disabled, while the non-empty `ssl_ciphers` fallback keeps the configuration compatible with Nginx's OpenSSL initialization.
+
+### A. HTTPS redirect proof
+
+```text
+HTTP/1.1 308 Permanent Redirect
+Server: nginx
+Date: Fri, 17 Jul 2026 14:26:45 GMT
+Content-Type: text/html
+Content-Length: 164
+Connection: keep-alive
+Location: https://localhost/
+X-Frame-Options: DENY
+X-Content-Type-Options: nosniff
+Referrer-Policy: strict-origin-when-cross-origin
+Permissions-Policy: camera=(), microphone=(), geolocation=()
+Cross-Origin-Opener-Policy: same-origin
+Cross-Origin-Resource-Policy: same-origin
+Content-Security-Policy-Report-Only: default-src 'self'; base-uri 'self'; object-src 'none'; frame-ancestors 'none'; form-action 'self'; script-src 'self'; style-src 'self'; img-src 'self' data:; connect-src 'self' wss:; upgrade-insecure-requests
+```
+
+### B. TLS 1.3 proof
+
+```text
+depth=0 CN = juice.local
+verify error:num=18:self signed certificate
+CONNECTION ESTABLISHED
+Protocol version: TLSv1.3
+Ciphersuite: TLS_AES_256_GCM_SHA384
+Peer certificate: CN = juice.local
+Hash used: SHA256
+Signature type: RSA-PSS
+Verification error: self signed certificate
+Server Temp Key: X25519, 253 bits
+DONE
+```
+
+### C. Security headers proof
+
+```text
+HTTP/2 200 
+server: nginx
+date: Fri, 17 Jul 2026 14:26:45 GMT
+content-type: text/html; charset=UTF-8
+content-length: 9903
+feature-policy: payment 'self'
+x-recruiting: /#/jobs
+accept-ranges: bytes
+cache-control: public, max-age=0
+last-modified: Fri, 17 Jul 2026 14:26:44 GMT
+etag: W/"26af-19f7078f9f9"
+vary: Accept-Encoding
+strict-transport-security: max-age=63072000; includeSubDomains; preload
+x-frame-options: DENY
+x-content-type-options: nosniff
+referrer-policy: strict-origin-when-cross-origin
+permissions-policy: camera=(), microphone=(), geolocation=()
+cross-origin-opener-policy: same-origin
+cross-origin-resource-policy: same-origin
+content-security-policy-report-only: default-src 'self'; base-uri 'self'; object-src 'none'; frame-ancestors 'none'; form-action 'self'; script-src 'self'; style-src 'self'; img-src 'self' data:; connect-src 'self' wss:; upgrade-insecure-requests
+```
+
+### What each header defends against
+
+- **HSTS:** forces future browser connections onto HTTPS, preventing SSL-stripping and accidental clear-text access after the first trusted response.
+- **X-Content-Type-Options: nosniff:** prevents browsers from reinterpreting a response as an executable MIME type different from the declared `Content-Type`.
+- **X-Frame-Options: DENY:** prevents the application from being embedded in an attacker-controlled frame and therefore reduces clickjacking risk.
+- **Referrer-Policy:** limits cross-origin referrers to the origin so sensitive paths and query strings are not leaked to other sites.
+- **Permissions-Policy:** denies camera, microphone, and geolocation access to the page and its embedded content unless the policy is deliberately relaxed.
+- **Content-Security-Policy-Report-Only:** reports resource loads that violate the strict same-origin policy so XSS and exfiltration controls can be tuned before enforcement.
+
+## Task 2: Production Posture
+
+### Rate limit proof
+
+The test sent an invalid login payload, so accepted requests may return an application-level 4xx instead of 200; HTTP 429 is the edge rejection that proves the Nginx control fired.
+
+| HTTP category | Count out of 60 |
+|---|---:|
+| 200 | 0 |
+| 429 | 54 |
+| Other 4xx | 6 |
+| 5xx | 0 |
+
+Raw summary:
+
+```text
+6 401
+54 429
+```
+
+### Timeout enforced
+
+This proof uses a TLS socket that sends an incomplete HTTP header and then waits. A plaintext `nc localhost 443` request would only test rejection of non-TLS traffic, not `client_header_timeout`.
+
+```text
+Outcome: connection closed
+Elapsed: 10.01 seconds
+```
+
+### Cipher hardening
+
+```text
+Server Temp Key: X25519, 253 bits
+New, TLSv1.3, Cipher is TLS_AES_256_GCM_SHA384
+```
+
+### Cert rotation runbook
+
+1. **Detect expiry:** monitor every production certificate and alert at 30 days, escalating to an on-call page at 7 days; also monitor failed automated renewals.
+2. **Order new cert:** renew through ACME/Let's Encrypt or the approved CA, generating the private key in the secret-management boundary rather than in the repository.
+3. **Validate:** inspect subject, SANs, issuer, serial, validity period, key usage, and chain with `openssl x509` and `openssl verify`; confirm that the key matches the certificate.
+4. **Atomic swap:** stage versioned certificate and key files, atomically repoint the `current` symlinks, run `nginx -t`, and perform a zero-downtime `nginx -s reload`.
+5. **Verify:** connect from outside the service with `openssl s_client`, `curl`, and `testssl.sh`; confirm the new serial, full chain, TLS 1.3, headers, and application health.
+6. **Rollback plan:** retain the previous known-good certificate and key for at least seven days and restore their symlinks followed by another tested Nginx reload if validation fails.
+7. **Audit:** record the operator or automation identity, change/ticket ID, certificate serial, expiry, validation output, deployment time, and rollback status in the SIEM/change log.
+
+### What OCSP stapling buys you
+
+In production, stapling lets Nginx periodically obtain a CA-signed revocation response and attach it to the TLS handshake, reducing client latency and preventing the CA from learning each client's browsing destination. A self-signed lab certificate has no issuing CA or OCSP responder, so there is no authoritative revocation response to staple; enabling it here would produce warnings without adding security.
+
+## Bonus: WAF Sidecar with OWASP CRS
+
+### Setup choice
+
+- **WAF used:** ModSecurity v3 with the official OWASP CRS Nginx image
+- **OWASP CRS version:** 4.25.1 LTS, pinned by the WAF Dockerfile
+- **Paranoia level:** blocking 1, detection 1
+- **Topology:** the lab exposes Nginx directly on 443 for the before/after comparison and the WAF on 8443; the WAF forwards allowed traffic to Nginx over TLS
+
+ModSecurity v3 was selected because the assignment explicitly accepts it and its official OWASP CRS container provides a reproducible CRS v4 deployment. Coraza would be a valid modern alternative, but using ModSecurity here keeps the exercise aligned with the task's documented examples and audit-log format.
+
+### Attack payload sent
+
+`GET /rest/products/search?q='%20OR%201=1--` (URL-encoded by `curl --data-urlencode`)
+
+### Before and after the WAF
+
+```text
+no-waf: HTTP 500
+with-waf: HTTP 403
+```
+
+### Audit log excerpt
+
+```text
+Access-Control-Max-Age: 3600
+Access-Control-Allow-Methods: GET, POST, PUT, DELETE, OPTIONS
+Access-Control-Allow-Headers: *
+
+---fSlATGKO---H--
+ModSecurity: Warning. detected SQLi using libinjection. [file "/etc/modsecurity.d/owasp-crs/rules/REQUEST-942-APPLICATION-ATTACK-SQLI.conf"] [line "46"] [id "942100"] [rev ""] [msg "SQL Injection Attack Detected via libinjection"] [data "Matched Data: s&1c found within ARGS:q: ' OR 1=1--"] [severity "2"] [ver "OWASP_CRS/4.25.1"] [maturity "0"] [accuracy "0"] [tag "application-multi"] [tag "language-multi"] [tag "platform-multi"] [tag "attack-sqli"] [tag "paranoia-level/1"] [tag "OWASP_CRS"] [tag "OWASP_CRS/ATTACK-SQLI"] [tag "capec/1000/152/248/66"] [hostname "localhost"] [uri "/rest/products/search"] [unique_id "178429841966.395850"] [ref "v28,10"]
+ModSecurity: Access denied with code 403 (phase 2). Matched "Operator `Ge' with parameter `5' against variable `TX:BLOCKING_INBOUND_ANOMALY_SCORE' (Value: `5' ) [file "/etc/modsecurity.d/owasp-crs/rules/REQUEST-949-BLOCKING-EVALUATION.conf"] [line "222"] [id "949110"] [rev ""] [msg "Inbound Anomaly Score Exceeded (Total Score: 5)"] [data ""] [severity "0"] [ver "OWASP_CRS/4.25.1"] [maturity "0"] [accuracy "0"] [tag "modsecurity"] [tag "anomaly-evaluation"] [tag "OWASP_CRS"] [hostname "localhost"] [uri "/rest/products/search"] [unique_id "178429841966.395850"] [ref ""]
+
+---fSlATGKO---I--
+
+---fSlATGKO---J--
+
+---fSlATGKO---Z--
+```
+
+Rule ID: **942100** — OWASP CRS rule name: **SQL Injection Attack Detected via libinjection**
+
+### Tradeoff analysis
+
+The WAF adds a runtime compensating control that can reject exploit patterns before they reach Juice Shop; SAST, DAST, and Conftest find source, runtime, or deployment problems but do not sit inline on every production request. The cost is latency, rule/configuration and certificate ownership, audit-log operations, and false positives that increase as paranoia levels rise. I would not deploy a self-managed WAF where the team cannot monitor and tune it, where strict API schemas and application controls already provide a smaller reliable attack surface, or where an inline availability dependency would create more risk than it removes.
+
+

--- a/submissions/lab3.md
+++ b/submissions/lab3.md
@@ -1,0 +1,1 @@
+lab3 signing test


### PR DESCRIPTION
## Goal

Deliver Lab 11 with a hardened Nginx reverse proxy, TLS 1.3, production edge controls, and a ModSecurity v3 + OWASP CRS WAF sidecar.

## Changes

- Hardened `labs/lab11/reverse-proxy/nginx.conf`: HTTP-to-HTTPS redirect, TLS 1.3 only, approved TLS 1.3 cipher suites, X25519, disabled session tickets and early data, and hardened session settings.
- Added HSTS, X-Content-Type-Options, X-Frame-Options, Referrer-Policy, Permissions-Policy, CSP Report-Only, COOP, and CORP response headers.
- Added login rate limiting, connection/request timeouts, upstream timeouts, and a documented certificate-rotation and rollback runbook.
- Added `labs/lab11/waf/Dockerfile` with the pinned `owasp/modsecurity-crs:4.25.1-nginx-alpine-lts` image.
- Added `labs/lab11/waf/docker-compose.override.yml` exposing the WAF on port `8443` and proxying accepted requests to the hardened Nginx endpoint over TLS.
- Added `submissions/lab11.md` with configuration excerpts, runtime evidence, security-header explanations, OCSP-stapling analysis, WAF evidence, and deployment tradeoffs.

## Testing

### Nginx configuration validation

```bash
docker compose -f labs/lab11/docker-compose.yml exec -T nginx nginx -t
# nginx: configuration file /etc/nginx/nginx.conf syntax is ok
# nginx: configuration file /etc/nginx/nginx.conf test is successful
```

### HTTP-to-HTTPS redirect

```bash
curl -sSI http://localhost | grep -Ei '^(HTTP/|Location:)'
# HTTP/1.1 308 Permanent Redirect
# Location: https://localhost/
```

### TLS 1.3, cipher suite, and key exchange

```bash
openssl s_client -connect localhost:443 -servername localhost -tls1_3 -brief </dev/null
# Protocol version: TLSv1.3
# Ciphersuite: TLS_AES_256_GCM_SHA384
# Server Temp Key: X25519, 253 bits
```

### Security response headers

```bash
curl -skI https://localhost | grep -Ei '^(strict-transport-security|x-content-type-options|x-frame-options|referrer-policy|permissions-policy|content-security-policy-report-only):'
# strict-transport-security: max-age=63072000; includeSubDomains; preload
# x-frame-options: DENY
# x-content-type-options: nosniff
# referrer-policy: strict-origin-when-cross-origin
# permissions-policy: camera=(), microphone=(), geolocation=()
# content-security-policy-report-only: default-src 'self'; base-uri 'self'; object-src 'none'; frame-ancestors 'none'; form-action 'self'; script-src 'self'; style-src 'self'; img-src 'self' data:; connect-src 'self' wss:; upgrade-insecure-requests
```

### Login rate limiting

```bash
seq 1 60 | xargs -P 30 -I{} curl -sk --max-time 10 -o /dev/null -w '%{http_code}\n' -H 'Content-Type: application/json' --data '{"email":"rate-limit-test@example.invalid","password":"invalid-password"}' https://localhost/rest/user/login | sort | uniq -c
#       6 401
#      54 429
```

The six HTTP `401` responses reached Juice Shop and the remaining 54 requests were rejected by Nginx with HTTP `429`.

### Slow-header timeout

The TLS socket test sent an incomplete HTTP request header and waited for the server to close the connection.

```bash
python3 - <<'PY'
import socket, ssl, time

context = ssl._create_unverified_context()
started = time.monotonic()
with socket.create_connection(("127.0.0.1", 443), timeout=5) as raw:
    with context.wrap_socket(raw, server_hostname="localhost") as tls:
        tls.settimeout(15)
        tls.sendall(b"GET / HTTP/1.1\r\nHost: localhost\r\nX-Slow: ")
        response = tls.recv(4096)

print("Outcome:", "HTTP response received" if response else "connection closed")
print(f"Elapsed: {time.monotonic() - started:.2f} seconds")
PY
# Outcome: connection closed
# Elapsed: 10.01 seconds
```

### WAF configuration validation

```bash
docker compose -f labs/lab11/docker-compose.yml -f labs/lab11/waf/docker-compose.override.yml exec -T waf nginx -t
# nginx: configuration file /etc/nginx/nginx.conf syntax is ok
# nginx: configuration file /etc/nginx/nginx.conf test is successful
```

### SQL-injection probe without and with the WAF

```bash
curl -sk -o /dev/null -w 'no-waf: HTTP %{http_code}\n' --get --data-urlencode "q=' OR 1=1--" https://localhost/rest/products/search
# no-waf: HTTP 500

curl -sk -o /dev/null -w 'with-waf: HTTP %{http_code}\n' --get --data-urlencode "q=' OR 1=1--" https://localhost:8443/rest/products/search
# with-waf: HTTP 403
```

The baseline Nginx endpoint forwarded the payload to Juice Shop, while the WAF rejected the same request before it reached the application.

### OWASP CRS audit evidence

```bash
docker compose -f labs/lab11/docker-compose.yml -f labs/lab11/waf/docker-compose.override.yml exec -T waf sh -c 'grep -E -m2 "\[id \"(942100|949110)\"\]" /var/log/modsec/audit.log'
# [id "942100"] [msg "SQL Injection Attack Detected via libinjection"] [ver "OWASP_CRS/4.25.1"]
# [id "949110"] [msg "Inbound Anomaly Score Exceeded (Total Score: 5)"] [ver "OWASP_CRS/4.25.1"]
```

Rule `942100` detected the SQL-injection payload at paranoia level 1, and rule `949110` enforced the HTTP `403` response.

## Artifacts & Screenshots

- `labs/lab11/reverse-proxy/nginx.conf` — hardened reverse-proxy configuration.
- `labs/lab11/waf/Dockerfile` — pinned ModSecurity v3 and OWASP CRS 4.25.1 image.
- `labs/lab11/waf/docker-compose.override.yml` — WAF sidecar deployment and TLS upstream configuration.
- `submissions/lab11.md` — complete submission report with runtime proof and security analysis.

## Checklist

- [x] Title is clear (`feat(lab11): hardened nginx + WAF sidecar`)
- [x] No secrets/large temp files committed
- [x] Submission file at `submissions/lab11.md` exists
- [x] Task 1 — TLS 1.3 + 6 security headers (with proof)
- [x] Task 2 — Rate limit + timeouts + cipher hardening + cert-rotation runbook
- [x] Bonus — Coraza/ModSec WAF + OWASP CRS catching a payload Nginx-alone passes.