### PR TITLE
docs(lec1,lab1): rewrite to a sourced, low-noise standard

### DIFF
--- a/README.md
+++ b/README.md
@@ -35,7 +35,7 @@ The course follows a **map → discover → write → ship → scan → harden �
 
 ## The Project: OWASP Juice Shop
 
-A deliberately-vulnerable web application maintained by Björn Kimminich since 2014; OWASP Flagship since 2018. The course pins **v20.0.0** (May 2026 release — Node 24, ~125 MB image, includes AI-themed prompt-injection challenges).
+A vulnerable-by-design web application created by Björn Kimminich in 2014, an OWASP Flagship project. The course pins **v20.0.0** (May 2026 release, Node 24, 112 challenges including chatbot prompt injection).
 
 ```mermaid
 graph LR
@@ -57,7 +57,7 @@ graph LR
 
 ## Lectures + Readings
 
-10 lectures, 17-25 slides each, 350-450 lines. Two readings replace lectures for the bonus labs.
+10 lectures plus two readings for the bonus labs. Every lecture ends with a Sources list; if a claim has no source there, open an issue.
 
 | # | Title | File |
 |--:|-------|------|
@@ -308,7 +308,7 @@ DevSecOps-Intro/
 <details>
 <summary>Standards & specs (bookmark these)</summary>
 
-- [OWASP Top 10:2025](https://owasp.org/Top10/2025/) — current; built from 175k+ CVE records
+- [OWASP Top 10:2025](https://owasp.org/Top10/2025/) — current edition; built from data on 2.8M+ applications
 - [OWASP Top 10 CI/CD Security Risks](https://owasp.org/www-project-top-10-ci-cd-security-risks/) — Lecture 4 framework
 - [OWASP SAMM v2.0](https://owaspsamm.org/) — maturity model
 - [SLSA v1.0](https://slsa.dev/spec/v1.0/) — supply-chain framework
@@ -322,10 +322,15 @@ DevSecOps-Intro/
 
 - *"What Happens When Falco Detects?"* — Loris Degioanni, KubeCon EU 2024
 - *"The xz Backdoor — Engineering Postmortem"* — Andres Freund, BSDCan 2024
-- *"OWASP Top 10:2025 — What Changed and Why"* — Andrew van der Stock, Global AppSec 2025
 - *"Sigstore: Software Signing for Everybody"* — Luke Hinds, KubeCon 2022
 
 </details>
+
+---
+
+## How This Course Is Built
+
+Lectures and labs are drafted with AI assistance and then edited by the instructor. Every command in a lab is executed before it ships, every date, number and quote in a lecture points to a source listed at the end of the lecture, and tool versions are re-pinned each semester. If a command fails or a fact looks wrong, open an issue in this repo; it is the fastest way to get it fixed for everyone.
 
 ---
 

--- a/README.md
+++ b/README.md
@@ -57,7 +57,7 @@ graph LR
 
 ## Lectures + Readings
 
-10 lectures plus two readings for the bonus labs. Every lecture ends with a Sources list; if a claim has no source there, open an issue.
+10 lectures, 17-25 slides each. Two readings replace lectures for the bonus labs.
 
 | # | Title | File |
 |--:|-------|------|
@@ -325,12 +325,6 @@ DevSecOps-Intro/
 - *"Sigstore: Software Signing for Everybody"* — Luke Hinds, KubeCon 2022
 
 </details>
-
----
-
-## How This Course Is Built
-
-Lectures and labs are drafted with AI assistance and then edited by the instructor. Every command in a lab is executed before it ships, every date, number and quote in a lecture points to a source listed at the end of the lecture, and tool versions are re-pinned each semester. If a command fails or a fact looks wrong, open an issue in this repo; it is the fastest way to get it fixed for everyone.
 
 ---
 

--- a/labs/lab1.md
+++ b/labs/lab1.md
@@ -11,7 +11,7 @@
 
 ## Setup
 
-- Docker 26 or newer (`docker --version`), Git 2.34 or newer, `curl`, `jq`, a GitHub account.
+- Docker 26 or newer (`docker --version`), Git 2.34 or newer, `curl`, `jq` (`brew install jq` or `apt install jq`), a GitHub account.
 - Fork the course repo, clone your fork, create the branch:
 
 ```bash
@@ -24,7 +24,7 @@ git switch -c feature/lab1
 
 ### 1.1 Run it
 
-The course pins `v20.0.0`.
+You do not build Juice Shop; you run the official image and observe it, the same posture you take with a production system. The course pins `v20.0.0`.
 
 ```bash
 docker run -d --name juice-shop -p 127.0.0.1:3000:3000 bkimminich/juice-shop:v20.0.0
@@ -46,7 +46,7 @@ Expected: `HTTP 200`, `{"version":"20.0.0"}`, `46`, and one `bkimminich/juice-sh
 
 ### 1.2 Look around
 
-Open http://127.0.0.1:3000 in a browser. Find the login and registration forms and the product list. In DevTools check Application → Local Storage for anything pre-populated, and in the Network tab watch what one product click requests and whether those requests need authentication.
+Open http://127.0.0.1:3000 in a browser and note what you find: the login and registration forms (Account menu, top right), the product list, any admin or account area you can discover, errors in the DevTools console, anything pre-populated in Application → Local Storage or cookies. In the Network tab click one product and watch the requests (`/api/Products/<id>/reviews` and similar): do they need authentication?
 
 Security headers:
 
@@ -63,7 +63,7 @@ Create `submissions/lab1.md` with a section `## Triage report` that contains:
 - Asset: image tag, image digest, host OS, Docker version.
 - Deployment: the run command, access URL, whether the port is bound to localhost only and why that matters, restart policy.
 - Health: HTTP code on `/`, the version and product-count outputs, the `docker ps` line.
-- Surface: what you found in 1.2, in your own words.
+- Surface: the five things you looked for in 1.2 (login and registration, products, admin or account area, console errors, local storage and cookies), in your own words.
 - Headers: the `curl -sI` output and which of the four headers are missing.
 - Top 3 risks: a name, 2-3 sentences on why it matters, and one OWASP Top 10:2025 category (A01 to A10) for each.
 
@@ -111,6 +111,7 @@ A preview of Lecture 4 on CI/CD security. Write `.github/workflows/lab1-smoke.ym
 #   - services: https://docs.github.com/en/actions/using-jobs/running-jobs-in-a-container
 #   - Juice Shop needs 20-30 seconds to start in CI; a 10-second loop fails
 #   - use pull_request, not pull_request_target (Lecture 4 explains why)
+#   - a tag pin is accepted in this first workflow; Lecture 4 covers pinning by digest
 ```
 
 Push, open the draft PR, and make the run green.
@@ -130,7 +131,7 @@ Open a PR from `your-fork:feature/lab1` to `course-repo:main`. The description s
 
 ## Acceptance criteria
 
-- Task 1 (6): `docker ps` shows the v20.0.0 container bound to `127.0.0.1:3000`; version and product-count outputs pasted; digest is a `sha256:` value from `RepoDigests`; all four headers classified as present or missing; three risks, each mapped to an A01 to A10 category.
+- Task 1 (6): `docker ps` shows the v20.0.0 container bound to `127.0.0.1:3000`; version and product-count outputs pasted; digest is a `sha256:` value from `RepoDigests`; all six report items filled with actual values; at least three of the four headers correctly classified as present or missing; three risks, each mapped to an A01 to A10 category.
 - Task 2 (3): template file exists with the four sections and the three checklist items; auto-fill shown on a real PR.
 - Task 3 (1): stars and follows done; section written.
 - Bonus (2): workflow triggers on `pull_request`, sets `permissions: contents: read` at workflow level, polls with a timeout, and the run on the submitted PR is green.

--- a/labs/lab1.md
+++ b/labs/lab1.md
@@ -5,44 +5,14 @@
 ![points](https://img.shields.io/badge/points-10%2B2-orange)
 ![tech](https://img.shields.io/badge/tech-Docker%20%2B%20GitHub-informational)
 
-> **Goal:** Deploy OWASP Juice Shop (the course's canonical attack target), produce a triage report, and bootstrap the PR-driven submission workflow you'll use for every subsequent lab.
-> **Deliverable:** A PR from `feature/lab1` to the course repo with `.github/PULL_REQUEST_TEMPLATE.md` and `submissions/lab1.md`. Submit PR link via Moodle.
-
----
-
-## Overview
-
-In this lab you will practice:
-- Deploying **OWASP Juice Shop** (Björn Kimminich's flagship vulnerable web app — Lecture 1, slide 4)
-- Producing a **triage report** — the artifact every appsec finding starts as
-- Bootstrapping a **PR template** + **submission workflow** for the rest of the course
-- Engaging with the open-source community on GitHub (small, but a real DevSecOps habit)
-
-> **You don't write Juice Shop.** You pull and run the official image. The skill is *operating* and *observing* — the same posture you'll use against real targets at work.
-
----
-
-## Project State
-
-**Starting point:** A GitHub account + Docker installed. This is Week 1.
-
-**After this lab:**
-- OWASP Juice Shop running locally on `127.0.0.1:3000`
-- A triage report (`submissions/lab1.md`) documenting the deployment + attack surface
-- A `.github/PULL_REQUEST_TEMPLATE.md` in your fork that every future PR uses
-- (Bonus) A baseline GitHub Actions workflow that smoke-tests Juice Shop on every PR
-
----
+> **Goal:** Run OWASP Juice Shop locally, write a triage report on what you see, and set up the PR workflow you will use for every lab.
+> **Deliverable:** A PR from `feature/lab1` with `.github/PULL_REQUEST_TEMPLATE.md` and `submissions/lab1.md`. Submit the PR link via Moodle.
+> **Used by:** Labs 4, 5, 7, 8 and 10 generate the SBOM of, scan, sign and triage this same image.
 
 ## Setup
 
-You need:
-- **Docker** (Docker Desktop on macOS/Windows, or `docker-ce` on Linux). `docker --version` should print `Docker version 26+` (any 26.x/27.x/28.x is fine).
-- **Git** ≥ 2.34
-- **A GitHub account**
-- **`curl`** + **`jq`** (`brew install jq` / `apt install jq` / built-in on most distros)
-
-Fork the course repo, then clone **your fork**:
+- Docker 26 or newer (`docker --version`), Git 2.34 or newer, `curl`, `jq`, a GitHub account.
+- Fork the course repo, clone your fork, create the branch:
 
 ```bash
 git clone https://github.com/<your-username>/DevSecOps-Intro.git
@@ -50,348 +20,134 @@ cd DevSecOps-Intro
 git switch -c feature/lab1
 ```
 
----
+## Task 1 — Deploy Juice Shop and write a triage report (6 pts)
 
-## Task 1 — Deploy Juice Shop & Triage Report (6 pts)
+### 1.1 Run it
 
-**Objective:** Run Juice Shop locally, verify it's working, capture a triage report covering deployment details + initial attack-surface observations.
-
-### 1.1: Deploy Juice Shop
-
-The course pins to **v20.0.0** (released May 2026, Node 24, ~125 MB image — Lecture 1 mentioned this is the leanest the image has been since v8).
+The course pins `v20.0.0`.
 
 ```bash
-docker run -d --name juice-shop \
-  -p 127.0.0.1:3000:3000 \
-  bkimminich/juice-shop:v20.0.0
+docker run -d --name juice-shop -p 127.0.0.1:3000:3000 bkimminich/juice-shop:v20.0.0
 ```
 
-> **Why `127.0.0.1:3000:3000` and not `-p 3000:3000`?** The former binds **only to localhost**. A bare `-p 3000:3000` exposes the container on every network interface — your laptop becomes a deliberately-vulnerable app on the public network. **One trailing space matters here.**
+`127.0.0.1:3000:3000` binds to localhost only. A bare `-p 3000:3000` publishes a vulnerable-by-design app on every interface, including the dorm Wi-Fi.
 
-Wait ~20 seconds for the app to start, then verify it's healthy:
+Wait about 20 seconds, then:
 
 ```bash
 docker ps --filter name=juice-shop --format 'table {{.Names}}\t{{.Status}}\t{{.Ports}}'
 curl -s -o /dev/null -w "HTTP %{http_code}\n" http://127.0.0.1:3000
-# v20.0.0 moved /rest/products → /api/Products; verify product count
+curl -s http://127.0.0.1:3000/rest/admin/application-version
 curl -s http://127.0.0.1:3000/api/Products | jq '.data | length'
-# Sanity: confirm version
-curl -s http://127.0.0.1:3000/rest/admin/application-version | jq
+docker inspect bkimminich/juice-shop:v20.0.0 --format '{{index .RepoDigests 0}}'
 ```
 
-You should see HTTP 200 on the homepage, ~46 products from `/api/Products`, and `{"version": "20.0.0"}` from the admin endpoint.
+Expected: `HTTP 200`, `{"version":"20.0.0"}`, `46`, and one `bkimminich/juice-shop@sha256:...` line. That digest goes into your report.
 
-### 1.2: Explore the Surface
+### 1.2 Look around
 
-Open `http://127.0.0.1:3000` in your browser. Note what you see:
+Open http://127.0.0.1:3000 in a browser. Find the login and registration forms and the product list. In DevTools check Application → Local Storage for anything pre-populated, and in the Network tab watch what one product click requests and whether those requests need authentication.
 
-- ✅ Is the landing page loading?
-- 🔑 Is there a Login + Registration form? (Should be in the top-right Account menu.)
-- 🛒 Are products listed?
-- 🛠️ Open DevTools → Application → Local Storage. Anything pre-populated?
-- 🌐 In Network tab, watch one product-detail click — note the `/api/Products/<id>/reviews` calls and whether they require auth.
-
-### 1.3: Triage Report
-
-Create `submissions/lab1.md` and **fill in the template below** with your real observations. Don't paraphrase — record what you actually saw.
-
-````markdown
-# Lab 1 — Submission
-
-## Triage Report: OWASP Juice Shop
-
-### Scope & Asset
-- Asset: OWASP Juice Shop (local lab instance)
-- Image: `bkimminich/juice-shop:v20.0.0`
-- Image digest: <sha256:... — get from `docker inspect juice-shop --format '{{.Image}}'`>
-- Host OS: <e.g. macOS 14.5 / Ubuntu 24.04>
-- Docker version: <output of `docker --version`>
-
-### Deployment Details
-- Run command used: `docker run -d --name juice-shop -p 127.0.0.1:3000:3000 bkimminich/juice-shop:v20.0.0`
-- Access URL: http://127.0.0.1:3000
-- Network exposure: 127.0.0.1 only? [ ] Yes [ ] No (explain if No)
-- Container restart policy: <default `no` or `--restart` flag?>
-
-### Health Check
-- HTTP code on `/`: <should be 200>
-- API check (first 200 chars of `/api/Products`):
-  ```
-  <paste output>
-  ```
-- Container uptime: <output of `docker ps --filter name=juice-shop`>
-
-### Initial Surface Snapshot (from browser exploration)
-- Login/Registration visible: [ ] Yes [ ] No — notes: <...>
-- Product listing/search present: [ ] Yes [ ] No — notes: <...>
-- Admin or account area discoverable: [ ] Yes [ ] No — notes: <...>
-- Client-side errors in DevTools console: [ ] Yes [ ] No — notes: <...>
-- Pre-populated local storage / cookies: <list what you saw>
-
-### Security Headers (Quick Look)
-Run: `curl -I http://127.0.0.1:3000 2>&1 | head -20`. Paste output:
-```
-<paste>
-```
-Which of these are MISSING? (cross-reference Lecture 1 OWASP Top 10:2025 — A06)
-- [ ] `Content-Security-Policy`
-- [ ] `Strict-Transport-Security`
-- [ ] `X-Content-Type-Options: nosniff`
-- [ ] `X-Frame-Options`
-
-### Top 3 Risks Observed (2-3 sentences each, in your own words)
-1. **<risk name>** — <why it matters; map to one OWASP Top 10:2025 category>
-2. **<risk name>** — <why; map to OWASP>
-3. **<risk name>** — <why; map to OWASP>
-````
-
-### 1.4: Cleanup (when done)
+Security headers:
 
 ```bash
-docker stop juice-shop
-# Keep the container around for future labs — Lab 4 (SBOM), Lab 5 (SAST/DAST), Lab 7 (image scan) all use it
-# To remove: docker rm juice-shop
+curl -sI http://127.0.0.1:3000 | head -20
 ```
 
----
+Decide which of these four are present: `Content-Security-Policy`, `Strict-Transport-Security`, `X-Content-Type-Options`, `X-Frame-Options`. Missing security headers fall under OWASP Top 10:2025 A02, Security Misconfiguration.
 
-## Task 2 — PR Template Setup (3 pts)
+### 1.3 Report
 
-**Objective:** Create a `.github/PULL_REQUEST_TEMPLATE.md` in your fork. Every PR from `feature/labN` will auto-fill this template — this is the workflow you'll use for the entire semester.
+Create `submissions/lab1.md` with a section `## Triage report` that contains:
 
-### 2.1: Create the template
+- Asset: image tag, image digest, host OS, Docker version.
+- Deployment: the run command, access URL, whether the port is bound to localhost only and why that matters, restart policy.
+- Health: HTTP code on `/`, the version and product-count outputs, the `docker ps` line.
+- Surface: what you found in 1.2, in your own words.
+- Headers: the `curl -sI` output and which of the four headers are missing.
+- Top 3 risks: a name, 2-3 sentences on why it matters, and one OWASP Top 10:2025 category (A01 to A10) for each.
+
+Actual values only. A placeholder left in the report costs points.
+
+### 1.4 Keep the container
 
 ```bash
-mkdir -p .github
-# YOUR TASK: create .github/PULL_REQUEST_TEMPLATE.md
+docker stop juice-shop   # do not `docker rm`: Labs 4, 5 and 7 reuse this image
 ```
 
-Required sections (the template must include all four):
+## Task 2 — PR template (3 pts)
 
-1. **Goal** — what this PR delivers (1 sentence)
-2. **Changes** — bullet list of artifacts added/modified
-3. **Testing** — how you verified it works (commands + observed output)
-4. **Artifacts & Screenshots** — links to files in this PR, image embeds where useful
+Create `.github/PULL_REQUEST_TEMPLATE.md` in your fork. GitHub pre-fills every new PR description with it.
 
-Required checklist (the template must include all three items):
+Required sections: **Goal** (one sentence), **Changes** (bullet list), **Testing** (commands and observed output), **Artifacts & Screenshots**.
 
-- [ ] Title is clear (`feat(labN): <topic>` style)
-- [ ] No secrets/large temp files committed
-- [ ] Submission file at `submissions/labN.md` exists
+Required checklist items: title follows `feat(labN): <topic>`; no secrets or large temp files committed; `submissions/labN.md` exists.
 
-> **Hint:** GitHub auto-detects `.github/PULL_REQUEST_TEMPLATE.md` and pre-fills the PR description box. To test, push the branch and open a PR draft — the template should appear before you write a single word.
+Test it: push the branch and open a draft PR. The description box must show your template before you type anything.
 
-### 2.2: Document in `submissions/lab1.md`
+**Submit:** a section `## PR template` in `submissions/lab1.md` with the file path, the section names, the checklist items, and a link to the draft PR (or a screenshot) showing the auto-filled description.
 
-Add a section:
+## Task 3 — GitHub community (1 pt)
 
-```markdown
-## PR Template Setup
+1. Star the course repository and [simple-container-com/api](https://github.com/simple-container-com/api).
+2. Follow the professor [@Cre-eD](https://github.com/Cre-eD) and the TAs [@Naghme98](https://github.com/Naghme98) and [@pierrepicaud](https://github.com/pierrepicaud).
+3. Follow at least three classmates.
 
-- File: `.github/PULL_REQUEST_TEMPLATE.md`
-- Sections included: Goal / Changes / Testing / Artifacts & Screenshots
-- Checklist items: <list yours>
-- Auto-fill verified: [ ] Yes — PR description showed my template (screenshot or link to draft PR)
-```
+**Submit:** a section `## GitHub community` with 1-2 sentences on why stars matter to open-source maintainers and how following people helps in team projects.
 
----
+## Bonus — Smoke test in GitHub Actions (2 pts)
 
-## Task 3 — GitHub Community Engagement (1 pt)
-
-**Objective:** Explore GitHub's social features that support collaboration and discovery.
-
-**Actions Required:**
-1. **Star** the course repository
-2. **Star** the [simple-container-com/api](https://github.com/simple-container-com/api) project — a promising open-source tool for container management
-3. **Follow** your professor and TAs on GitHub:
-   - Professor: [@Cre-eD](https://github.com/Cre-eD)
-   - TA: [@Naghme98](https://github.com/Naghme98)
-   - TA: [@pierrepicaud](https://github.com/pierrepicaud)
-4. **Follow** at least 3 classmates from the course
-
-**Add to `submissions/lab1.md`:**
-
-A "GitHub Community" section with 1-2 sentences explaining:
-- Why starring repositories matters in open source
-- How following developers helps in team projects and professional growth
-
-<details>
-<summary>💡 GitHub Social Features</summary>
-
-**Why Stars Matter:**
-- Stars help you bookmark interesting projects for later reference
-- Star count indicates project popularity and community trust
-- Starred repos appear in your GitHub profile, showing your interests
-- Stars encourage maintainers and help projects gain visibility
-
-**Why Following Matters:**
-- See what other developers are working on
-- Discover new projects through their activity
-- Build professional connections beyond the classroom
-- Stay updated on classmates' work for future collaboration
-
-</details>
-
----
-
-## Bonus Task — Smoke-Test Workflow in GitHub Actions (2 pts)
-
-> 🌟 **Genuinely challenging — not just wiring.** This task previews Lecture 4 (CI/CD Security). You'll write a real workflow that runs Juice Shop in CI and verifies it works.
-
-**Objective:** Create `.github/workflows/lab1-smoke.yml` that, on every PR, pulls Juice Shop, runs it as a service, curls the homepage, and fails the build if Juice Shop doesn't respond healthy.
-
-### B.1: Write the workflow
+A preview of Lecture 4 on CI/CD security. Write `.github/workflows/lab1-smoke.yml`:
 
 ```yaml
-# .github/workflows/lab1-smoke.yml
-# YOUR TASK: Smoke-test Juice Shop in CI
+# YOUR TASK: smoke-test Juice Shop on every PR
 # Requirements:
-#   - Triggers on pull_request to main
-#   - Uses ubuntu-latest runner
-#   - permissions: { contents: read } at workflow level (Lecture 4, slide 7)
-#   - Pulls bkimminich/juice-shop:v20.0.0 (pin the tag — recall Lecture 4 SHA-pinning rationale; we accept a tag here since this is your first workflow)
-#   - Runs it as a service or via `docker run -d`
-#   - Waits up to 60s for it to be ready (loop with `curl --silent --fail`)
-#   - Fails the job if the homepage returns non-200 or never starts
-#
+#   - on: pull_request to main; runs-on: ubuntu-latest
+#   - permissions: { contents: read } at workflow level
+#   - starts bkimminich/juice-shop:v20.0.0 (a services: block, or docker run -d in a step)
+#   - polls http://localhost:3000/rest/admin/application-version with `curl --silent --fail`
+#     for up to 60 seconds; the job fails if it never gets a 200
 # Hints:
-#   - GitHub Actions `services:` block is one elegant way (https://docs.github.com/en/actions/using-jobs/running-jobs-in-a-container)
-#   - Alternative: a single `steps:` job with `docker run -d` + a polling loop
-#   - The polling loop pattern (Juice Shop v20: use /rest/admin/application-version, not /rest/products):
-#       for i in $(seq 1 30); do
-#         curl --silent --fail http://localhost:3000/rest/admin/application-version >/dev/null && exit 0
-#         sleep 2
-#       done
-#       exit 1
+#   - services: https://docs.github.com/en/actions/using-jobs/running-jobs-in-a-container
+#   - Juice Shop needs 20-30 seconds to start in CI; a 10-second loop fails
+#   - use pull_request, not pull_request_target (Lecture 4 explains why)
 ```
 
-### B.2: Verify it runs
+Push, open the draft PR, and make the run green.
 
-1. Commit + push the workflow to `feature/lab1`
-2. Open a draft PR
-3. The Actions tab should show your workflow running. **It must succeed.**
-4. Click the run, expand the smoke-test step, copy the part that shows the curl response
+**Submit:** a section `## Bonus: CI smoke test` with the workflow path, the run URL, the run duration, and the curl output excerpt from the job log.
 
-### B.3: Document in `submissions/lab1.md`
-
-````markdown
-## Bonus: CI Smoke Test
-
-- Workflow file: `.github/workflows/lab1-smoke.yml`
-- Trigger: `pull_request` on main
-- Run URL (must be green): <link to your Actions run>
-- Workflow run duration: <e.g. 45s>
-- Curl response excerpt:
-  ```
-  <paste your "HTTP/1.1 200 OK ..." block>
-  ```
-````
-
----
-
-## How to Submit
+## Submit
 
 ```bash
-git add .github/PULL_REQUEST_TEMPLATE.md
-git add .github/workflows/lab1-smoke.yml    # only if you did the bonus
-git add submissions/lab1.md
+git add .github/PULL_REQUEST_TEMPLATE.md submissions/lab1.md
+git add .github/workflows/lab1-smoke.yml   # bonus only
 git commit -m "feat(lab1): juice shop deploy + PR template + triage report"
 git push -u origin feature/lab1
 ```
 
-Open a PR from `your-fork:feature/lab1` → `course-repo:main`. The PR description should auto-fill with your template — that itself is part of the proof. Submit the PR URL in Moodle.
+Open a PR from `your-fork:feature/lab1` to `course-repo:main`. The description should auto-fill from your template. Submit the PR URL in Moodle.
 
-PR checklist (paste this into your PR body):
+## Acceptance criteria
 
-```text
-- [x] Task 1 done — Juice Shop deployed, triage report in submissions/lab1.md
-- [ ] Task 2 done — .github/PULL_REQUEST_TEMPLATE.md created
-- [ ] Task 3 done — GitHub stars + follows complete
-- [ ] Bonus done — lab1-smoke.yml runs green on this PR
-```
+- Task 1 (6): `docker ps` shows the v20.0.0 container bound to `127.0.0.1:3000`; version and product-count outputs pasted; digest is a `sha256:` value from `RepoDigests`; all four headers classified as present or missing; three risks, each mapped to an A01 to A10 category.
+- Task 2 (3): template file exists with the four sections and the three checklist items; auto-fill shown on a real PR.
+- Task 3 (1): stars and follows done; section written.
+- Bonus (2): workflow triggers on `pull_request`, sets `permissions: contents: read` at workflow level, polls with a timeout, and the run on the submitted PR is green.
 
----
+## Common pitfalls
 
-## Acceptance Criteria
-
-### Task 1 (6 pts)
-- ✅ Juice Shop v20.0.0 container running on `127.0.0.1:3000` (proof: `docker ps` output in submission)
-- ✅ Homepage returns HTTP 200; `/api/Products` returns a JSON list
-- ✅ Triage report has all six sections filled in with **real** values (no template placeholders left)
-- ✅ At least three security headers are correctly identified as present or missing
-- ✅ Top 3 risks each mapped to an OWASP Top 10:2025 category (A01–A10)
-
-### Task 2 (3 pts)
-- ✅ `.github/PULL_REQUEST_TEMPLATE.md` exists in the fork
-- ✅ Template includes all four required sections
-- ✅ Template includes a 3-item checklist
-- ✅ Auto-fill verified (PR description shows the template before any manual edits)
-
-### Task 3 (1 pt)
-- ✅ Starred course repo and simple-container-com/api
-- ✅ Following professor, TAs, and 3+ classmates
-- ✅ GitHub Community section in submission
-
-### Bonus Task (2 pts)
-- ✅ `.github/workflows/lab1-smoke.yml` exists and triggers on `pull_request`
-- ✅ Workflow run is **green** on the submitted PR (run URL in submission)
-- ✅ Workflow uses `permissions: { contents: read }` at workflow level
-- ✅ Smoke test verifies HTTP 200 from Juice Shop within the timeout
-
----
-
-## Rubric
-
-| Task | Points | Criteria |
-|------|-------:|----------|
-| **Task 1** — Deploy + Triage | **6** | Container running on localhost-only port + full triage report with real values + headers analysis + 3 risks mapped to OWASP Top 10:2025 |
-| **Task 2** — PR Template | **3** | All 4 sections + 3-item checklist + auto-fill working on a real PR |
-| **Task 3** — GitHub Community | **1** | Stars, follows, and written explanation |
-| **Bonus Task** — CI Smoke Test | **2** | Green workflow run on the submitted PR with proper permissions block and timeout-bounded healthcheck |
-| **Total** | **12** | 10 main + 2 bonus |
-
----
+- `docker ps` shows nothing: the container exited. Run `docker logs juice-shop`; usually port 3000 is taken (`ss -ltnp | grep 3000` or `lsof -i :3000`).
+- `/rest/products` returns 500 in v20: the product API is `/api/Products` (capital P, `{"data": [...]}` envelope). Use `/rest/admin/application-version` as the health check.
+- Empty JSON or connection refused right after start: wait 20 seconds and retry.
+- `docker inspect juice-shop --format '{{.Image}}'` prints the local image ID, not the registry digest. Use `RepoDigests` on the image, as in 1.1.
+- The PR template does not appear: the file must be `.github/PULL_REQUEST_TEMPLATE.md` (lowercase `pull_request_template.md` also works; pick one).
+- The bonus workflow times out: poll for 60 seconds, not 10.
 
 ## Resources
 
-<details>
-<summary>📚 Documentation</summary>
-
-- [OWASP Juice Shop](https://owasp.org/www-project-juice-shop/) — Official project page
-- [Pwning OWASP Juice Shop](https://pwning.owasp-juice.shop/) — The companion book (free, online)
-- [Juice Shop v20.0.0 release notes](https://owasp.org/blog/2026/05/13/juice-shop-v20) — What's new
-- [GitHub PR Template docs](https://docs.github.com/en/communities/using-templates-to-encourage-useful-issues-and-pull-requests/creating-a-pull-request-template-for-your-repository) — File-location conventions
-- [GitHub Actions services block](https://docs.github.com/en/actions/using-jobs/running-jobs-in-a-container) — For the bonus
-- [OWASP Top 10:2025](https://owasp.org/Top10/2025/) — Use this to map your top-3 risks
-
-</details>
-
-<details>
-<summary>⚠️ Common Pitfalls</summary>
-
-- 🚨 **`-p 3000:3000` exposes Juice Shop on every interface**, including your office WiFi. **Always** use `-p 127.0.0.1:3000:3000` for any deliberately-vulnerable app. Use `docker network inspect bridge` to verify.
-- 🚨 **`docker ps` shows nothing** — the container exited. Check `docker logs juice-shop` for the actual error. Most common: another process on port 3000 (run `lsof -i :3000` or `ss -ltnp | grep 3000`).
-- 🚨 **`/rest/products` returns 404 in v20.0.0** — Juice Shop's API moved. Use `/api/Products` (capital P, returns `{data: [...]}` envelope) for product listing. Use `/rest/admin/application-version` for a simple JSON health check.
-- 🚨 **API returns empty/502 instead of JSON** — Juice Shop takes ~20s to fully start on a cold image. Wait, then re-curl.
-- 🚨 **PR template doesn't auto-fill** — file must be exactly `.github/PULL_REQUEST_TEMPLATE.md` (capital + singular). Variants like `.github/PR_TEMPLATE.md` or `.github/pull_request_template.md` (lowercase) work too — but be consistent in your fork.
-- 🚨 **Bonus workflow times out** — Juice Shop v20.0.0 needs ~20-30s in CI. Don't set your loop to 10s and quit.
-- 🚨 **Bonus workflow uses `pull_request_target` instead of `pull_request`** — Lecture 4 covers why that's a critical-class PPE bug. For this lab: use `pull_request`, period.
-- 🚨 **Forgetting to set the workflow's `permissions:` block** — defaults are write on many older repos. Explicitly set `contents: read` at workflow level.
-- 💡 **Image digest:** `docker inspect juice-shop --format '{{.Image}}'` gives you the digest for the triage report. Pin to digest in real production work (Lecture 4 — SHA-pinning for actions, same principle for images).
-
-</details>
-
-<details>
-<summary>🪜 Looking ahead</summary>
-
-Juice Shop will be the target throughout the course. Future labs that re-use what you set up here:
-- **Lab 3** (Secure Git) — sign your `feature/labN` commits
-- **Lab 4** (SBOM/SCA) — generate an SBOM of the v20.0.0 image you ran today
-- **Lab 5** (SAST/DAST) — scan Juice Shop source + run ZAP against the running container
-- **Lab 7** (Container Security) — Trivy scan + Docker Bench on the same image
-- **Lab 8** (Supply Chain) — rebuild + sign your own version with Cosign
-- **Lab 10** (Vuln Management) — import every prior lab's findings on Juice Shop into DefectDojo
-
-Get the deployment right today; it pays for the entire semester.
-
-</details>
+- [OWASP Juice Shop](https://owasp.org/www-project-juice-shop/) and [Pwning OWASP Juice Shop](https://pwning.owasp-juice.shop/), the free companion book
+- [Juice Shop v20.0.0 release](https://github.com/juice-shop/juice-shop/releases/tag/v20.0.0)
+- [OWASP Top 10:2025](https://owasp.org/Top10/2025/), for mapping your three risks
+- [Creating a pull request template](https://docs.github.com/en/communities/using-templates-to-encourage-useful-issues-and-pull-requests/creating-a-pull-request-template-for-your-repository)
+- [GitHub Actions service containers](https://docs.github.com/en/actions/using-jobs/running-jobs-in-a-container)

--- a/lectures/lec1.md
+++ b/lectures/lec1.md
@@ -1,308 +1,373 @@
-# Lecture 1 — DevSecOps Foundations: From "Add Security Later" to "Security Everywhere"
+# 📌 Lecture 1 — DevSecOps Foundations: From "Add Security Later" to "Security Everywhere"
 
 ---
 
-## Slide 1 – Equifax, 2017: the patch that was never applied
+## 📍 Slide 1 – 💥 The $1.4 Billion Patch That Wasn't Applied
 
-- March 7, 2017: Apache discloses CVE-2017-5638, a remote code execution bug in Struts 2, and ships the patch the same day.
-- March 8: US-CERT notifies Equifax. March 9: Equifax security emails a patch directive to its administrators.
-- March 10: attackers first exploit the bug on the ACIS dispute portal. A March 15 scan does not flag the portal, so it stays unpatched.
-- May 13 to July 30: the attackers pull records on about 147 million people: names, birth dates, Social Security numbers, driver's licence numbers.
-- July 29: Equifax renews a TLS-inspection certificate that had expired ten months earlier. Decrypted traffic becomes visible again and the breach is noticed within a day.
-- Total cost to Equifax: about $1.4 billion in security spending and settlements, including a settlement of up to $700 million with the FTC, CFPB and US states.
+* 🗓️ **March 7, 2017** — Apache discloses **CVE-2017-5638**, an RCE in Struts 2. Patch ships **the same day**. CVSS 10.0
+* 📧 March 9: Equifax's security team emails the patch directive across the company
+* 🌀 The vulnerable web portal isn't on the inventory the directive used. **It is missed**
+* 🗓️ **March 10**: someone is already exploiting it
+* 💾 May 13 – July 30: **147 million records** exfiltrated — names, SSNs, birth dates, license numbers
+* 🚨 July 29: Equifax discovers the breach. CEO and CISO resign within weeks
+* 💰 Final cost: **~$1.4 billion** in remediation + settlements
 
-> Think: the patch existed, the directive went out, the fix was free. What failed was the process between "we have a control" and "the control catches the bug". That gap is what this course is about.
-
----
-
-## Slide 2 – Learning outcomes
-
-By the end of this lecture you can:
-
-1. Define DevSecOps and tell it apart from "DevOps plus a scanner".
-2. Explain shift-left with the cost-of-defect argument, and say where the argument stops.
-3. Name the OWASP Top 10:2025 categories and what changed since 2021.
-4. Map three breaches (Equifax, Capital One, Log4Shell) to the practice that would have caught each.
-5. Describe the pipeline you will have built by Lab 10.
+> 🤔 **Think:** The patch existed. The directive went out. The fix was free. **What process failure cost a billion dollars?** That gap — between "we have a security control" and "the control actually catches the bug" — is what this course is about.
 
 ---
 
-## Slide 3 – Course map
+## 📍 Slide 2 – 🎯 Learning Outcomes (this lecture)
+
+| # | 🎓 Outcome |
+|---|-----------|
+| 1 | ✅ Define DevSecOps and explain how it differs from "DevOps + a security tool" |
+| 2 | ✅ Place the shift-left philosophy on a real cost-of-defect curve |
+| 3 | ✅ Recite the **OWASP Top 10 (2025)** categories and what changed from 2021 |
+| 4 | ✅ Walk through three real breaches (Equifax 2017, Capital One 2019, Log4Shell 2021) and identify which DevSecOps practice each one would have caught |
+| 5 | ✅ Describe what your DevSecOps pipeline will look like by the end of the course |
+
+---
+
+## 📍 Slide 3 – 🗺️ Course Map: Where We're Going
 
 ```mermaid
 graph LR
-    L1["L1 Foundations"] --> L2["L2 Threat modeling"]
-    L2 --> L3["L3 Secure Git"]
-    L3 --> L4["L4 CI/CD + SBOM"]
-    L4 --> L5["L5 SAST / DAST"]
-    L5 --> L6["L6 IaC scanning"]
-    L6 --> L7["L7 Containers + K8s"]
-    L7 --> L8["L8 Supply chain"]
-    L8 --> L9["L9 Runtime detection"]
-    L9 --> L10["L10 Vuln management"]
+    L1["🏛️ L1 Foundations<br/>(this)"] --> L2["🎯 L2 Threat<br/>modeling"]
+    L2 --> L3["🔐 L3 Secure<br/>Git"]
+    L3 --> L4["🚀 L4 CI/CD<br/>security"]
+    L4 --> L5["🧪 L5 SAST/<br/>DAST"]
+    L5 --> L6["🏗️ L6 IaC<br/>scanning"]
+    L6 --> L7["📦 L7 Container<br/>security"]
+    L7 --> L8["🔏 L8 Supply<br/>chain"]
+    L8 --> L9["📊 L9 Runtime +<br/>metrics"]
+    L9 --> L10["🎯 L10 Vuln<br/>management"]
+
     style L1 fill:#FF9800,color:#fff
     style L10 fill:#4CAF50,color:#fff
 ```
 
-- Every lab targets the same application, OWASP Juice Shop. By Week 10 you will have run every defensive practice in the course against one attack surface.
-- The order is the order of a software lifecycle: model, write, ship, scan, harden, sign, detect, triage.
+* 🎯 **Through-line:** every lab targets **OWASP Juice Shop** — the most famously broken web app in the world. By Week 10 you'll have run every defensive practice against the same attack surface
+* 🪜 **The arc:** culture → modeling → write secure code → ship secure code → scan secure code → secure infrastructure → secure containers → secure supply chain → detect at runtime → triage findings
 
 ---
 
-## Slide 4 – The project: OWASP Juice Shop
+## 📍 Slide 4 – 🍹 The Project: OWASP Juice Shop
 
-- Created by Björn Kimminich in 2014, accepted as an OWASP project in 2016, now an OWASP Flagship project.
-- The course pins v20.0.0 (May 2026). It ships 112 challenges in 16 categories: 16 Sensitive Data Exposure, 13 Injection, 12 Broken Access Control, 12 Improper Input Validation, 9 XSS, 9 Broken Authentication, and so on.
-- Stack: Node.js, Angular, SQLite, JWT sessions, file uploads. The bugs are the kind found in production code, not `eval(user_input)` toys.
-- The score board at `/#/score-board` is ground truth: when a scanner reports a finding in Lab 5, you can check whether it found a known challenge or noise.
-- Lab 1 deploys it. Labs 4, 5, 7, 8 and 10 generate its SBOM, scan its code and its running instance, scan and sign its image, and triage everything in DefectDojo.
+* 🏗️ Created by **Björn Kimminich** in 2014; OWASP project since 2016, now an OWASP Flagship project
+* 🐛 v20.0.0 ships **112 challenges** in 16 categories (13 Injection, 12 Broken Access Control, 16 Sensitive Data Exposure, ...)
+* 🚢 Docker one-liner: `docker run -d -p 127.0.0.1:3000:3000 bkimminich/juice-shop:v20.0.0`
+* 🎯 **Why Juice Shop is the canonical learning target:**
+  * Realistic stack (Node.js, Angular, SQLite, JWT, file uploads)
+  * Bugs are intentional but **realistic** — not "use eval(user_input)" toy examples
+  * Has a known set of challenges — the score board at `/#/score-board` is ground truth for checking scanner output
+* 🧪 Lab 1 deploys it; Labs 4, 5, 7, 8, 10 keep attacking it from different angles
+
+> 🧠 Juice Shop is broken on purpose, but in the way production applications are broken: realistic stack, realistic bugs, documented answers to check your tools against
 
 ---
 
-## Slide 5 – What DevSecOps is
+## 📍 Slide 5 – 🧭 What Is DevSecOps?
 
-- January 2012: Gartner analyst Neil MacDonald writes "DevOps Needs to Become DevOpsSec": security has to be built into DevOps workflows rather than bolted on.
-- September 2016: Gartner publishes "DevSecOps: How to Seamlessly Integrate Security Into DevOps" (MacDonald and Head). Security is integrated at multiple points of the pipeline, "largely transparent to developers", without losing the speed of DevOps.
-- Working definition for this course: security controls that run **as code, in the pipeline, at every stage, owned by the team that ships**.
+```mermaid
+flowchart LR
+    Dev["👩‍💻 Dev"] -.-> Build["🏗️ Build"]
+    Ops["🖥️ Ops"] -.-> Build
+    Sec["🛡️ Sec"] -.-> Build
+    Build --> DevSecOps["🚀 DevSecOps<br/>Continuous, automated security<br/>at every stage"]
 
-| "DevOps plus a scanner" | DevSecOps |
+    style DevSecOps fill:#FF9800,color:#fff
+```
+
+* 🧑‍🏫 **Origin:** January 2012, Gartner analyst **Neil MacDonald** writes *"DevOps Needs to Become DevOpsSec"*. September 2016, the Gartner report *DevSecOps: How to Seamlessly Integrate Security Into DevOps* (MacDonald & Head) fixes the name: security integrated at multiple points of the pipeline, *"largely transparent to developers"*, without losing DevOps speed
+* 🪜 **DevOps + a SAST tool ≠ DevSecOps.** The defining shift is *cultural*: security is **everyone's job**, executed **as code**, **early** and **often**
+* 📚 First book-length treatment: *"DevOpsSec"* by **Jim Bird** (O'Reilly, 2016)
+* 🚫 **What DevSecOps is NOT:**
+  * Not a tool you buy
+  * Not "the security team approves the pipeline"
+  * Not a one-time audit before launch
+
+---
+
+## 📍 Slide 6 – 🕰️ A 25-Year Timeline
+
+| 🗓️ Year | 📍 Milestone |
 |---|---|
-| One tool, one stage, owned by the security team | Controls at commit, build, deploy and runtime |
-| Findings emailed as a PDF | Findings fail the build or open a ticket with an owner |
-| Security reviews the release | Security writes rules; developers fix in the PR |
-
-- What DevSecOps is not: a product you buy, a security team that approves pipelines, an audit before launch.
-
----
-
-## Slide 6 – Timeline
-
-| Year | Milestone |
-|---|---|
-| 2001 | Manifesto for Agile Software Development, Snowbird, Utah. OWASP founded. |
-| 2003 | First OWASP Top 10. |
-| 2009 | First DevOpsDays in Ghent, organised by Patrick Debois; the word "DevOps" comes from the event name. |
-| 2012 | Gartner: "DevOps Needs to Become DevOpsSec". |
-| 2016 | Gartner DevSecOps report; Jim Bird, *DevOpsSec* (O'Reilly). |
-| 2017 | Equifax breach. |
-| 2019 | Capital One breach. |
-| 2020 | SolarWinds Orion build compromise (CISA alert AA20-352A, December 2020). |
-| 2021 | Log4Shell. |
-| 2024 | NIST Cybersecurity Framework 2.0 adds the Govern function. |
-| 2025 | OWASP Top 10:2025. |
+| 2001 | Manifesto for Agile Software Development — Snowbird, UT. OWASP founded |
+| 2009 | Patrick Debois coins **"DevOps"** at the first DevOpsDays (Ghent, BE) |
+| 2003 | First OWASP Top 10 |
+| 2012 | **Gartner** blog *DevOps Needs to Become DevOpsSec* — Neil MacDonald |
+| 2016 | Gartner *DevSecOps* report; first book-length treatment — *DevOpsSec* (Jim Bird, O'Reilly) |
+| 2017 | Equifax breach — DevSecOps becomes a boardroom topic |
+| 2019 | Capital One breach — cloud misconfiguration joins the agenda |
+| 2020 | SolarWinds — supply-chain security joins the agenda |
+| 2021 | Log4Shell — runtime detection joins the agenda |
+| 2024 | NIST CSF 2.0 adds the *Govern* function |
+| 2025 | **OWASP Top 10:2025** published; supply-chain failures get their own category |
 
 ---
 
-## Slide 7 – A defect costs more the later you find it
+## 📍 Slide 7 – 💸 The Cost-of-Defect Curve
 
-- Barry Boehm, *Software Engineering Economics* (1981): on large projects, fixing a defect after delivery cost up to 100 times more than fixing it during requirements.
-- Boehm and Basili, "Software Defect Reduction Top 10 List" (IEEE Computer, 2001): for small, non-critical systems the factor is closer to 5:1. The popular "10x per phase" is a slogan; the direction is what the data supports.
-- NIST, *The Economic Impacts of Inadequate Infrastructure for Software Testing* (2002): software defects cost the US economy about $59.5 billion a year; better testing infrastructure could remove about $22.2 billion of that.
+> 📖 Barry Boehm, *Software Engineering Economics* (Prentice Hall, **1981**): on large projects a defect fixed after delivery cost up to **100×** a requirements-phase fix. Boehm & Basili (*IEEE Computer*, 2001) put small, non-critical systems closer to **5:1**. The popular "10× per stage" is a slogan; the direction is what the data supports
 
 ```mermaid
 graph LR
-    R["Requirements"] --> D["Design"] --> C["Code"] --> T["Test"] --> P["Production"]
+    R[📝 Requirements<br/>cheapest fix] --> D[📐 Design]
+    D --> C[💻 Code]
+    C --> T[🧪 Testing]
+    T --> P[🚨 Production<br/>most expensive fix]
+
     style R fill:#4CAF50,color:#fff
     style P fill:#F44336,color:#fff
 ```
 
-- DevSecOps in one sentence: run each check at the earliest point where it still produces a useful signal.
+* 📊 NIST, *The Economic Impacts of Inadequate Infrastructure for Software Testing* (2002): software defects cost the US about **$59.5 billion a year**; better testing infrastructure could remove about **$22.2 billion** of it
+* 🎯 **DevSecOps in one diagram:** push every security check **as far left** as it will still produce useful signal
 
 ---
 
-## Slide 8 – Shift-left, and where it stops
+## 📍 Slide 8 – ⬅️ Shift-Left, Pragmatically
 
-| Control | Where it moves to | Lab |
+* 🪜 **Shift-Left** = run security checks earlier in the pipeline, where fixes are cheap
+* ⚠️ But: *"shift-left" doesn't mean "**only** left"* — runtime threats still need runtime defense (Lecture 9)
+* 🪛 **In this course:** every lab maps to a leftward shift of one specific control:
+
+| 🛠️ Control | 📍 Where it shifts to | 🧪 Lab |
 |---|---|---|
-| Threat modeling | Design | 2 |
-| Secret detection | Pre-commit hook | 3 |
-| SBOM and dependency scan | Build | 4 |
-| SAST | Pull request | 5 |
-| IaC scanning | Pull request | 6 |
-| Image scan, pod hardening | Image build, deploy | 7 |
-| Signing and verification | Deploy gate | 8 |
-| Runtime detection | Cluster | 9 |
-| Triage, SLAs, metrics | Program | 10 |
+| Threat modeling | Design | L2 |
+| Secret leak detection | Pre-commit | L3 |
+| SAST | PR build | L5 |
+| SCA / SBOM | Build | L4 |
+| IaC scanning | PR build | L6 |
+| Image scan | Image build | L7 |
+| Signing/verification | Deploy gate | L8 |
+| Runtime detection | Cluster | L9 |
 
-- Shift-left does not mean only-left. Log4Shell (Slide 15) was unknown to every scanner until December 9, 2021; the teams that coped had runtime detection and an inventory, not a better SAST rule.
-- Labs 9 and 10 exist because some bugs only show up in production.
+* 🧠 The *opposite* of shift-left is "shift-right-only" = a SOC reading post-mortems. Both ends are valid; **the middle is where DevSecOps adds value**
 
 ---
 
-## Slide 9 – Culture, process, tools
+## 📍 Slide 9 – 🪜 Three Pillars (Culture, Process, Tools)
 
-| Pillar | What it means | Without it |
+| 🏛️ Pillar | 🎯 What it means | 🔥 What goes wrong without it |
 |---|---|---|
-| Culture | The team that ships owns the fix | Security becomes a queue; findings age |
-| Process | Threat modeling, SLAs per severity, post-incident reviews | The same bug class ships every release |
-| Tools | SAST, DAST, SCA, IaC and runtime checks in the pipeline | Quarterly PDF nobody reads |
+| 👥 **Culture** | Shared accountability; "if a dev wrote it, a dev fixes it" | Security team becomes the bottleneck; devs throw work over the wall |
+| 🛠️ **Process** | Threat modeling, defined SLAs, post-incident reviews | Heroics; same vulns ship every release |
+| 🤖 **Tools** | Automated SAST/DAST/SCA/IaC/runtime in the pipeline | Manual scans = quarterly findings dump nobody reads |
 
-- DORA, *Accelerate State of DevOps 2022* (33,000 respondents): the strongest predictor of adopting security practices is cultural, a high-trust, low-blame culture. Supply-chain security controls improved delivery performance, but only where continuous integration was already in place.
-- This course spends ten weeks rather than three because the tools are the easy part.
+* 🪜 **DORA, Accelerate State of DevOps 2022** (33,000 respondents): the strongest predictor of adopting security practices is a **high-trust, low-blame culture**; supply-chain security controls improved delivery performance only where continuous integration was already in place
+* 🧪 *"Tools are necessary but not sufficient."* If we only taught tools this course would be 3 weeks long. **It's 10 weeks because process and culture matter more.**
 
 ---
 
-## Slide 10 – CIA, plus two properties you will implement
+## 📍 Slide 10 – 🔒 The CIA Triad — and Two Modern Additions
 
-| Property | Meaning | Where you build it |
+```mermaid
+graph TB
+    CIA[🔐 Classical CIA] --> C[🔏 Confidentiality<br/>only authorized see]
+    CIA --> I[✅ Integrity<br/>only authorized change]
+    CIA --> A[🟢 Availability<br/>authorized always reach]
+    CIA -.modern.-> AU[🪪 Authenticity<br/>identity is real]
+    CIA -.modern.-> NR[📜 Non-Repudiation<br/>can't deny the action]
+
+    style C fill:#2196F3,color:#fff
+    style I fill:#4CAF50,color:#fff
+    style A fill:#FF9800,color:#fff
+```
+
+* 🏛️ **CIA Triad:** the classical model every security course starts from
+* 🪪 **Authenticity** matters now because of phishing + AI-generated content
+* 📜 **Non-Repudiation** matters now because of regulatory reporting (GDPR, HIPAA)
+* 🧠 Lab 3 (signed commits) is the first non-repudiation control you'll deploy
+
+---
+
+## 📍 Slide 11 – 🏆 OWASP and the Top 10:2025
+
+* 🌐 **OWASP** = Open Worldwide Application Security Project — community-driven non-profit, **founded 2001**
+* 🏆 The **Top 10** is a periodic ranking of the most critical web app risks. Releases: **2003, 2004, 2007, 2010, 2013, 2017, 2021, 2025**
+* 🆕 **OWASP Top 10:2025** — the 8th edition — built from data on **2.8 million+ applications** from 13 organisations: 589 CWEs analysed, 248 mapped into the ten categories; 8 categories come from the data, 2 from the community survey
+* 🔄 **What's new vs 2021:**
+  * 🆕 **A03: Software Supply Chain Failures** (widens 2021's A06 "Vulnerable and Outdated Components" to the whole build and distribution ecosystem)
+  * 🆕 **A10: Mishandling of Exceptional Conditions**
+  * 🪜 SSRF absorbed into **A01 Broken Access Control** (it was a category of its own in 2021)
+  * ✏️ Renamed: A07 **Authentication Failures**, A09 **Security Logging & Alerting Failures**
+
+---
+
+## 📍 Slide 12 – 🔥 OWASP Top 10:2025 — The List
+
+| # | 🏷️ Category | 🎯 Plain English |
 |---|---|---|
-| Confidentiality | Only authorised parties read the data | Lab 3 (no secrets in Git), Lab 11 (TLS) |
-| Integrity | Only authorised parties change the data or the code | Lab 8 (signed images) |
-| Availability | Authorised parties can reach the system | Lab 11 (rate limiting), Lab 12 (isolation) |
-| Authenticity | The artifact comes from who it claims | Lab 8 (provenance attestations) |
-| Non-repudiation | The author cannot deny the action | Lab 3 (signed commits) |
+| **A01** | Broken Access Control | Users do things they shouldn't be allowed to (now includes SSRF) |
+| **A02** | Security Misconfiguration | Defaults, debug pages, missing headers, open S3 buckets |
+| **A03** | **Software Supply Chain Failures** 🆕 | Compromised libs, builds, broken provenance |
+| **A04** | Cryptographic Failures | Weak/missing encryption, hard-coded secrets |
+| **A05** | Injection | SQL, NoSQL, command, LDAP — untrusted input as code |
+| **A06** | Insecure Design | The *architecture* invites the bug |
+| **A07** | Authentication Failures | Weak passwords, broken MFA, session fixation |
+| **A08** | Software or Data Integrity Failures | Unsigned updates, unsafe deserialization |
+| **A09** | Security Logging & Alerting Failures | Can't detect because we can't see |
+| **A10** | **Mishandling of Exceptional Conditions** 🆕 | Error paths leak info, fail-open instead of fail-closed |
+
+* 🧠 **Every lab in this course defends against at least one A0X category.** Worth bookmarking this slide
 
 ---
 
-## Slide 11 – OWASP and the Top 10:2025
-
-- OWASP, the Open Worldwide Application Security Project, is a non-profit founded in 2001. The Top 10 has been published in 2003, 2004, 2007, 2010, 2013, 2017, 2021 and 2025.
-- The 2025 edition is built from data on more than 2.8 million applications contributed by 13 organisations. 589 CWEs were analysed; 248 of them map into the ten categories. Eight categories come from the data, two from the community survey.
-- Changes since 2021:
-  - A03 Software Supply Chain Failures widens the old A06 Vulnerable and Outdated Components to cover the whole build and distribution ecosystem.
-  - A10 Mishandling of Exceptional Conditions is new: error paths that leak information or fail open.
-  - Server-Side Request Forgery, its own category in 2021, is folded into A01 Broken Access Control.
-  - A07 is renamed Authentication Failures; A09 is renamed Security Logging & Alerting Failures.
-
----
-
-## Slide 12 – The list, and where the course meets each category
-
-| # | Category | In plain terms | Labs |
-|---|---|---|---|
-| A01 | Broken Access Control | Users reach data or actions they should not, including SSRF | 2, 5 |
-| A02 | Security Misconfiguration | Defaults, debug endpoints, missing headers, open buckets | 1, 6, 7 |
-| A03 | Software Supply Chain Failures | Compromised or unverified dependencies, builds, distribution | 4, 8 |
-| A04 | Cryptographic Failures | Weak or missing encryption, secrets in code | 3, 11 |
-| A05 | Injection | Untrusted input executed as SQL, NoSQL, shell, LDAP | 5 |
-| A06 | Insecure Design | The architecture invites the bug | 2 |
-| A07 | Authentication Failures | Weak passwords, broken sessions, missing MFA | 5 |
-| A08 | Software or Data Integrity Failures | Unsigned updates, unsafe deserialisation | 8 |
-| A09 | Security Logging & Alerting Failures | Attacks nobody sees | 9 |
-| A10 | Mishandling of Exceptional Conditions | Stack traces to users, fail-open error paths | 5, 10 |
-
-- Lab 1 asks you to map three observed risks to these categories. Use this table and the OWASP page.
-
----
-
-## Slide 13 – Why Injection is still on the list after twenty years
+## 📍 Slide 13 – 💉 Why Injection Hasn't Left the Top 10 in 20 Years
 
 ```python
-# bad: string concatenation
+# ❌ Vulnerable — string concatenation
 def get_user(username):
     cursor.execute(f"SELECT * FROM users WHERE name = '{username}'")
-    # input:  bob' OR '1'='1
-    # query:  SELECT * FROM users WHERE name = 'bob' OR '1'='1'
+    # Input: bob' OR '1'='1
+    # Becomes: SELECT * FROM users WHERE name = 'bob' OR '1'='1'
 
-# good: parameterised query
+# ✅ Safe — parameterized query
 def get_user(username):
     cursor.execute("SELECT * FROM users WHERE name = ?", (username,))
 ```
 
-- The fix is one line once you see it. The problem is that the first version looks fine until you think like an attacker.
-- Juice Shop v20.0.0 has 13 Injection challenges (SQL and NoSQL). In Lab 5, Semgrep flags the vulnerable patterns in the source before you find them by hand.
+* 🧠 The fix is **trivial** when developers know it. The teaching problem is that **string concat looks fine** until you imagine an attacker
+* 🪜 **Lab 5** (SAST with Semgrep) will catch this exact pattern automatically — your first concrete shift-left win
+* 🎯 OWASP Juice Shop v20.0.0 ships **13 Injection challenges** (SQL and NoSQL); you'll find the vulnerable patterns with Semgrep before you find them by hand
 
 ---
 
-## Slide 14 – Case study: Capital One, 2019
+## 📍 Slide 14 – 🔬 Case Study: Capital One (2019)
 
-- A former AWS employee sent Server-Side Request Forgery requests through a misconfigured open-source web application firewall running on an EC2 instance. The WAF fetched the EC2 instance metadata service and returned the instance role's temporary credentials.
-- Those credentials could list and read more than 700 S3 buckets. About 106 million credit applications were taken, including about 140,000 Social Security numbers and 80,000 bank account numbers.
-- Consequences: an $80 million civil penalty from the OCC (2020), a $190 million class-action settlement, and a federal conviction for the attacker (2022).
-- In course terms: an IaC scan (Lab 6) flags an instance role with wildcard S3 permissions; a threat model (Lab 2) marks the metadata service as a trust boundary; runtime detection (Lab 9) sees a WAF host suddenly reading S3. In OWASP Top 10:2025 numbering this is A01, since SSRF now lives there.
-
----
-
-## Slide 15 – Case study: Log4Shell, 2021
-
-- November 24, 2021: Chen Zhaojun of Alibaba Cloud reports CVE-2021-44228 to the Apache Logging project. December 6: a fix appears in 2.15.0-rc1. December 9: the bug is public and exploited within hours. CVSS 10.0.
-- The bug: Log4j 2 resolves `${jndi:ldap://...}` inside a log message, so any logged user input can load and run remote code.
-- Log4j is embedded in a large share of Java software, so the first question everywhere was "which of our services contain log4j-core, and which version?"
-- In course terms: an SBOM (Lab 4) answers that question in minutes instead of days; dependency scanning (Lab 4) flags the vulnerable version; runtime detection (Lab 9) catches the outbound LDAP connection from a service that never makes one.
+* 🗓️ **July 19, 2019** — Capital One learns that a former AWS employee has used **SSRF** through a **misconfigured WAF** on EC2 to read the instance metadata service and take the role's credentials
+* 🪜 The WAF's IAM role had wildcard `s3:Get*` / `s3:List*` across **700+ buckets**
+* 💾 Exfiltration: **106 million records**, 140,000 SSNs
+* 💰 **$80M** OCC civil penalty (2020) + **$190M** class-action settlement; the attacker was convicted in 2022
+* 🧠 **The lessons in DevSecOps terms:**
+  * 🏗️ **IaC scan** (L6) would have flagged the wildcard IAM
+  * 🎯 **Threat modeling** (L2) would have surfaced the metadata service as a trust boundary
+  * 📊 **Runtime detection** (L9) on outbound S3 calls would have caught the exfiltration mid-flight
 
 ---
 
-## Slide 16 – Secure SDLC: where each lab sits
+## 📍 Slide 15 – 🔬 Case Study: Log4Shell (2021)
 
-| Phase | Practice | Labs |
+* 🗓️ **November 24, 2021** — Alibaba security team discloses CVE-2021-44228 (CVSS 10.0) in **Log4j 2**
+* 🌍 **Log4j is everywhere** — embedded in millions of Java apps, including Minecraft, iCloud, Steam, Tesla
+* 🐛 The bug: log messages are interpreted as JNDI lookups → arbitrary code execution from a log line
+* 🐍 December 9, 2021: PoC goes public. The internet rewrites Christmas plans
+* 🧠 **In DevSecOps terms:**
+  * 📋 **SBOM** (L4) — could you instantly say *"do my services depend on Log4j 2?"* Most companies couldn't on day one
+  * 🔏 **Supply-chain signing** (L8) — verifying provenance doesn't fix vuln deps, but it lets you know *which exact version* you have, fast
+  * 📊 **Runtime detection** (L9) — a service that never talks LDAP suddenly opening an outbound LDAP/JNDI connection is exactly the kind of event a runtime rule catches
+
+> 🤔 **Think:** Log4Shell was a code-level bug, but every defense that worked was at a **higher** layer (SBOM, runtime detection). What does that tell you about defense-in-depth?
+
+---
+
+## 📍 Slide 16 – 🧩 Secure SDLC: The Five Phases
+
+```mermaid
+flowchart LR
+    R[📝 Requirements] --> D[📐 Design]
+    D --> I[💻 Implement]
+    I --> V[🧪 Verify]
+    V --> O[🚀 Operate]
+    O -.feedback.-> R
+
+    style R fill:#FF9800,color:#fff
+    style D fill:#9C27B0,color:#fff
+    style I fill:#2196F3,color:#fff
+    style V fill:#4CAF50,color:#fff
+    style O fill:#F44336,color:#fff
+```
+
+| 🪜 Phase | 🛡️ DevSecOps practice | 🧪 Lab |
 |---|---|---|
-| Requirements | Abuse cases, security stories | lecture only |
-| Design | Threat modeling with STRIDE, trust boundaries | 2 |
-| Implement | Signed commits, secret scanning | 3 |
-| Verify | SBOM, SCA, SAST, DAST, IaC and image scanning, signing | 4 to 8 |
-| Operate | Runtime detection, vulnerability management, metrics | 9, 10 |
+| Requirements | Security stories, abuse cases | (Lecture-only) |
+| Design | Threat modeling (STRIDE), data classification | **L2** |
+| Implement | Signed commits, secret scanning, secure coding | **L3** |
+| Verify | SAST, DAST, IaC scan, container scan, SBOM/SCA | **L4–L8** |
+| Operate | Runtime detection, vuln management, metrics | **L9–L10** |
 
-- NIST SP 800-218, the Secure Software Development Framework, is the reference standard for this table; Lecture 9 returns to it.
+* 🪜 **The whole point of this course is that practice goes in each phase** — by Week 10 you'll have something running in every one
 
 ---
 
-## Slide 17 – Maturity models and roles
+## 📍 Slide 17 – 🪜 Maturity Models — Where You'll End Up
 
-- OWASP SAMM (Software Assurance Maturity Model): 15 security practices, each scored at maturity level 1 (initial), 2 (structured, repeatable) or 3 (optimised, measured). Lecture 9 walks through it.
-- BSIMM (Building Security In Maturity Model, Black Duck): an annual descriptive study of what real programs do, useful for benchmarking.
-- Moving from level 1 to level 2 in SAMM terms means documenting what already happens and making it repeat every release, not buying a tool.
+* 🏛️ **OWASP SAMM** — *Software Assurance Maturity Model* — 15 practices, each scored at maturity 1 (initial), 2 (structured, repeatable) or 3 (optimised, measured). We'll do a proper walkthrough in Lecture 9
+* 📊 **BSIMM** — *Building Security In Maturity Model* (Black Duck) — descriptive annual study of what real programs do; useful for benchmarking
+* 🪜 Moving from level 1 to level 2 means **documenting what already happens and making it repeat every release**, not buying a tool
+* 🎯 **End-of-course goal:** every student should be able to **describe a Level 2 program** and identify *one concrete gap* to push their team toward Level 3 — this is exam-territory material
 
-| Role | Owns | In this course |
+---
+
+## 📍 Slide 18 – 🏢 Roles in a DevSecOps Team
+
+| 🧑‍💼 Role | 🎯 Responsibility | 👀 Where you meet them in the course |
 |---|---|---|
-| Developer | Writes code, fixes findings in the PR | every lab |
-| DevOps / SRE | Pipeline, deploy hardening | 4, 7 |
-| Security engineer | Detection rules, custom policies | 6, 9 |
-| Security champion | A developer with security training, embedded in a product team, reviews PRs | lecture only |
-| Security manager | SLAs, metrics, reporting | 10 |
+| 👩‍💻 **Developer** | Writes code, runs SAST locally, fixes findings | Every lab |
+| 🚀 **DevOps/SRE** | Maintains the pipeline; deploys hardening | L4, L7 |
+| 🛡️ **Security Engineer** | Writes detection rules, custom policies | L6, L9 |
+| 🦸 **Security Champion** | Developer trained in security; embeds in dev teams | Lecture-only |
+| 🎯 **Security Architect** | Designs trust boundaries, signs off threat models | L2 |
+| 📊 **Security Manager** | Owns metrics, SLAs, exec reporting | L10 |
 
-- The OWASP Security Champions Guide describes how to start a champions program; it is the role that scales DevSecOps beyond the security team.
+* 🪜 **"Security Champion" is the role that scales DevSecOps in real orgs** — one developer per team trained to push back on PRs that ship vulnerable code. Read the OWASP Security Champions Guide when you have a quiet hour
 
 ---
 
-## Slide 18 – Five things you will hear at your first job
+## 📍 Slide 19 – 🚫 The Five Myths You'll Hear at Your First Job
 
-| Claim | What the evidence says |
+| 😱 Myth | 🧠 Reality |
 |---|---|
-| "Security slows us down" | DORA 2022: supply-chain security controls improved delivery performance where CI was in place |
-| "We'll add security after the MVP" | Boehm: the later the fix, the higher the cost; the MVP becomes the legacy system |
-| "We have a firewall" | Capital One had a WAF; the WAF was the entry point. Modern traffic is HTTPS through port 443 and the perimeter says nothing about the application |
-| "The scanner shows zero criticals" | Scanners find known patterns; on December 8, 2021 every scanner showed zero Log4Shell findings |
-| "That's the security team's problem" | Equifax security sent the directive; the team that ran the portal never saw it. Ownership sits with the team that runs the system |
+| *"Security slows us down"* | DORA 2022: supply-chain security controls **improved** delivery performance where CI was already in place |
+| *"We'll do security after MVP"* | The MVP becomes the legacy system; Boehm's curve says every month of delay makes the fix dearer |
+| *"We have a firewall"* | Modern apps speak HTTPS through firewalls; perimeter security is a 1990s mental model |
+| *"Our scanner shows 0 critical, so we're secure"* | Scanners find *known* bugs. Your unknowns are your unknowns. (Threat modeling, L2) |
+| *"That's the security team's problem"* | The security team can't be in every PR. Distributed ownership is the only model that scales |
+
+* 🧠 You'll hear at least three of these in the first month of any real DevSecOps job. The point of this course is to give you the data + stories to push back without sounding theoretical
 
 ---
 
-## Slide 19 – Lab 1, next lecture, reading
+## 📍 Slide 20 – 📚 Resources & What's Next
 
-Lab 1 this week:
-- Task 1 (6 pts): run Juice Shop v20.0.0 on localhost, write a triage report, map three risks to the Top 10:2025.
-- Task 2 (3 pts): a PR template your fork uses for every lab.
-- Task 3 (1 pt): GitHub community engagement.
-- Bonus (2 pts): a GitHub Actions smoke test of Juice Shop; a preview of Lecture 4.
+**Books to keep on your desk:**
 
-Next week: Lecture 2, threat modeling with STRIDE and Threagile. Bring a diagram of any system you have worked on.
+| 📖 Book | ✍️ Why |
+|---|---|
+| *DevOpsSec* — Jim Bird (O'Reilly, 2016, free report) | Still the most accessible DevSecOps overview |
+| *Securing DevOps* — Julien Vehent (Manning, 2018) | A real pipeline at Mozilla, tool by tool |
+| *The DevOps Handbook* — Kim, Humble, Debois, Willis (2nd ed., 2021) | The DevOps cultural foundation that DevSecOps extends |
+| *Web Application Security* — Andrew Hoffman (2nd ed., O'Reilly, 2024) | Companion to the attacks Juice Shop contains |
 
-Books:
-- Jim Bird, *DevOpsSec* (O'Reilly, 2016). Short, free, the clearest overview of the idea.
-- Julien Vehent, *Securing DevOps* (Manning, 2018). A real pipeline at Mozilla, tool by tool.
-- Kim, Humble, Debois, Willis, *The DevOps Handbook*, 2nd ed. (IT Revolution, 2021). The cultural foundation DevSecOps extends.
-- Andrew Hoffman, *Web Application Security*, 2nd ed. (O'Reilly, 2024). Companion to the attacks Juice Shop contains.
+**Talks (1–2 hours, worth your time):**
 
-Talks: Julien Vehent, "Beyond the Security Team" (DevSecCon Seattle, 2019); Vehent, "Tools & Techniques from Building a DevSecOps Culture at Mozilla" (SBA Live Academy, 2020).
+* 🎥 *"Beyond the Security Team"* — Julien Vehent, DevSecCon Seattle 2019
+* 🎥 *"Tools & Techniques from Building a DevSecOps Culture at Mozilla"* — Julien Vehent, SBA Live Academy 2020
 
-> "Security is a process, not a product." Bruce Schneier, *Information Security Magazine*, April 2000.
+**Standards & specs (bookmark them):**
+
+* 📜 [OWASP Top 10:2025](https://owasp.org/Top10/2025/)
+* 📜 [OWASP Juice Shop](https://owasp.org/www-project-juice-shop/)
+* 📜 [NIST SSDF (SP 800-218)](https://csrc.nist.gov/Projects/ssdf) — the canonical secure-SDLC standard
+
+**Next week:** Lecture 2 — **Threat Modeling with STRIDE and Threagile**. Bring a system diagram of any app you've worked on; we'll model it.
+
+> 💬 *"Security is a process, not a product."* — Bruce Schneier, *Information Security Magazine*, April 2000 — and still true 26 years later.
 
 ---
 
-## Sources
+## 📚 Sources
 
-- Equifax timeline, root causes: US House Committee on Oversight, *The Equifax Data Breach* (Dec 2018), https://oversight.house.gov/wp-content/uploads/2018/12/Equifax-Report.pdf ; CSO Online FAQ, https://www.csoonline.com/article/567833/equifax-data-breach-faq-what-happened-who-was-affected-what-was-the-impact.html
-- Equifax settlement (up to $700M): FTC, https://www.ftc.gov/enforcement/refunds/equifax-data-breach-settlement
-- Gartner 2012 blog: https://blogs.gartner.com/neil_macdonald/2012/01/17/devops-needs-to-become-devopssec/ ; Gartner 2016 report: https://www.gartner.com/en/documents/3463417
-- Jim Bird, *DevOpsSec*: https://www.oreilly.com/library/view/devopssec/9781491971413/
-- Agile Manifesto history: https://agilemanifesto.org/history.html ; DevOpsDays Ghent 2009: https://devopsdays.org/events/2009-ghent/
-- OWASP Top 10 project and editions: https://owasp.org/www-project-top-ten/ ; Top 10:2025 list and introduction (data figures, changes): https://owasp.org/Top10/2025/ , https://owasp.org/Top10/2025/0x00_2025-Introduction/
-- NIST CSF 2.0: https://www.nist.gov/cyberframework ; SolarWinds, CISA AA20-352A: https://www.cisa.gov/news-events/cybersecurity-advisories/aa20-352a
-- Boehm and Basili 2001: https://www.cs.umd.edu/projects/SoftEng/ESEG/papers/82.78.pdf ; NIST 2002 software testing study: https://www.rti.org/sites/default/files/resources/software_testing.pdf
+- Equifax timeline and root causes: US House Committee on Oversight, *The Equifax Data Breach* (Dec 2018), https://oversight.house.gov/wp-content/uploads/2018/12/Equifax-Report.pdf ; CSO Online FAQ, https://www.csoonline.com/article/567833/equifax-data-breach-faq-what-happened-who-was-affected-what-was-the-impact.html ; FTC settlement, https://www.ftc.gov/enforcement/refunds/equifax-data-breach-settlement
+- Gartner 2012 blog: https://blogs.gartner.com/neil_macdonald/2012/01/17/devops-needs-to-become-devopssec/ ; Gartner 2016 report: https://www.gartner.com/en/documents/3463417 ; Jim Bird, *DevOpsSec*: https://www.oreilly.com/library/view/devopssec/9781491971413/
+- Agile Manifesto history: https://agilemanifesto.org/history.html ; DevOpsDays Ghent 2009: https://devopsdays.org/events/2009-ghent/ ; NIST CSF 2.0: https://www.nist.gov/cyberframework ; SolarWinds, CISA AA20-352A: https://www.cisa.gov/news-events/cybersecurity-advisories/aa20-352a
+- Boehm & Basili 2001: https://www.cs.umd.edu/projects/SoftEng/ESEG/papers/82.78.pdf ; NIST 2002 software testing study: https://www.rti.org/sites/default/files/resources/software_testing.pdf
 - DORA 2022 report: https://dora.dev/research/2022/dora-report/
+- OWASP Top 10 project and editions: https://owasp.org/www-project-top-ten/ ; Top 10:2025 list and introduction (data figures, changes): https://owasp.org/Top10/2025/ , https://owasp.org/Top10/2025/0x00_2025-Introduction/
 - Capital One: DOJ conviction release (2022), https://www.justice.gov/usao-wdwa/pr/former-seattle-tech-worker-convicted-wire-fraud-and-computer-intrusions ; OCC $80M penalty (2020), https://www.occ.gov/news-issuances/news-releases/2020/nr-occ-2020-101.html
 - Log4Shell: Apache Logging security page, https://logging.apache.org/security.html ; CISA alert, https://www.cisa.gov/news-events/alerts/2021/12/10/apache-releases-log4j-version-2150-address-critical-rce-vulnerability ; Datadog timeline, https://www.datadoghq.com/blog/log4j-log4shell-vulnerability-overview-and-remediation/
-- OWASP SAMM: https://owaspsamm.org/model/ ; BSIMM: https://www.blackduck.com/services/security-program/bsimm-maturity-model.html ; OWASP Security Champions Guide: https://owasp.org/www-project-security-champions-guidebook/
-- NIST SSDF SP 800-218: https://csrc.nist.gov/Projects/ssdf
+- OWASP SAMM: https://owaspsamm.org/model/ ; BSIMM: https://www.blackduck.com/services/security-program/bsimm-maturity-model.html ; OWASP Security Champions Guide: https://owasp.org/www-project-security-champions-guidebook/ ; NIST SSDF: https://csrc.nist.gov/Projects/ssdf
 - Juice Shop project: https://owasp.org/www-project-juice-shop/ ; v20.0.0 release and challenge list: https://github.com/juice-shop/juice-shop/releases/tag/v20.0.0
 - Books: https://www.manning.com/books/securing-devops , https://itrevolution.com/product/the-devops-handbook-second-edition/ , https://www.oreilly.com/library/view/web-application-security/9781098143923/
 - Talks: http://jvehent.org/2019/09/30/beyond_the_security_team.html , https://www.slideshare.net/SBA-Research/tools-amp-techniques-building-a-dev-secops-culture-at-mozilla-sba-live-academy-may-2020-234913386

--- a/lectures/lec1.md
+++ b/lectures/lec1.md
@@ -1,362 +1,309 @@
-# 📌 Lecture 1 — DevSecOps Foundations: From "Add Security Later" to "Security Everywhere"
+# Lecture 1 — DevSecOps Foundations: From "Add Security Later" to "Security Everywhere"
 
 ---
 
-## 📍 Slide 1 – 💥 The $1.4 Billion Patch That Wasn't Applied
+## Slide 1 – Equifax, 2017: the patch that was never applied
 
-* 🗓️ **March 7, 2017** — Apache discloses **CVE-2017-5638**, an RCE in Struts 2. Patch ships **the same day**. CVSS 10.0
-* 📧 March 9: Equifax's security team emails the patch directive across the company
-* 🌀 The vulnerable web portal isn't on the inventory the directive used. **It is missed**
-* 🗓️ **March 10**: someone is already exploiting it
-* 💾 May 13 – July 30: **147 million records** exfiltrated — names, SSNs, birth dates, license numbers
-* 🚨 July 29: Equifax discovers the breach. CEO and CISO resign within weeks
-* 💰 Final cost: **~$1.4 billion** in remediation + settlements
+- March 7, 2017: Apache discloses CVE-2017-5638, a remote code execution bug in Struts 2, and ships the patch the same day.
+- March 8: US-CERT notifies Equifax. March 9: Equifax security emails a patch directive to its administrators.
+- March 10: attackers first exploit the bug on the ACIS dispute portal. A March 15 scan does not flag the portal, so it stays unpatched.
+- May 13 to July 30: the attackers pull records on about 147 million people: names, birth dates, Social Security numbers, driver's licence numbers.
+- July 29: Equifax renews a TLS-inspection certificate that had expired ten months earlier. Decrypted traffic becomes visible again and the breach is noticed within a day.
+- Total cost to Equifax: about $1.4 billion in security spending and settlements, including a settlement of up to $700 million with the FTC, CFPB and US states.
 
-> 🤔 **Think:** The patch existed. The directive went out. The fix was free. **What process failure cost a billion dollars?** That gap — between "we have a security control" and "the control actually catches the bug" — is what this course is about.
-
----
-
-## 📍 Slide 2 – 🎯 Learning Outcomes (this lecture)
-
-| # | 🎓 Outcome |
-|---|-----------|
-| 1 | ✅ Define DevSecOps and explain how it differs from "DevOps + a security tool" |
-| 2 | ✅ Place the shift-left philosophy on a real cost-of-defect curve |
-| 3 | ✅ Recite the **OWASP Top 10 (2025)** categories and what changed from 2021 |
-| 4 | ✅ Walk through three real breaches (Equifax 2017, Capital One 2019, Log4Shell 2021) and identify which DevSecOps practice each one would have caught |
-| 5 | ✅ Describe what your DevSecOps pipeline will look like by the end of the course |
+> Think: the patch existed, the directive went out, the fix was free. What failed was the process between "we have a control" and "the control catches the bug". That gap is what this course is about.
 
 ---
 
-## 📍 Slide 3 – 🗺️ Course Map: Where We're Going
+## Slide 2 – Learning outcomes
+
+By the end of this lecture you can:
+
+1. Define DevSecOps and tell it apart from "DevOps plus a scanner".
+2. Explain shift-left with the cost-of-defect argument, and say where the argument stops.
+3. Name the OWASP Top 10:2025 categories and what changed since 2021.
+4. Map three breaches (Equifax, Capital One, Log4Shell) to the practice that would have caught each.
+5. Describe the pipeline you will have built by Lab 10.
+
+---
+
+## Slide 3 – Course map
 
 ```mermaid
 graph LR
-    L1["🏛️ L1 Foundations<br/>(this)"] --> L2["🎯 L2 Threat<br/>modeling"]
-    L2 --> L3["🔐 L3 Secure<br/>Git"]
-    L3 --> L4["🚀 L4 CI/CD<br/>security"]
-    L4 --> L5["🧪 L5 SAST/<br/>DAST"]
-    L5 --> L6["🏗️ L6 IaC<br/>scanning"]
-    L6 --> L7["📦 L7 Container<br/>security"]
-    L7 --> L8["🔏 L8 Supply<br/>chain"]
-    L8 --> L9["📊 L9 Runtime +<br/>metrics"]
-    L9 --> L10["🎯 L10 Vuln<br/>management"]
-
+    L1["L1 Foundations"] --> L2["L2 Threat modeling"]
+    L2 --> L3["L3 Secure Git"]
+    L3 --> L4["L4 CI/CD + SBOM"]
+    L4 --> L5["L5 SAST / DAST"]
+    L5 --> L6["L6 IaC scanning"]
+    L6 --> L7["L7 Containers + K8s"]
+    L7 --> L8["L8 Supply chain"]
+    L8 --> L9["L9 Runtime detection"]
+    L9 --> L10["L10 Vuln management"]
     style L1 fill:#FF9800,color:#fff
     style L10 fill:#4CAF50,color:#fff
 ```
 
-* 🎯 **Through-line:** every lab targets **OWASP Juice Shop** — the most famously broken web app in the world. By Week 10 you'll have run every defensive practice against the same attack surface
-* 🪜 **The arc:** culture → modeling → write secure code → ship secure code → scan secure code → secure infrastructure → secure containers → secure supply chain → detect at runtime → triage findings
+- Every lab targets the same application, OWASP Juice Shop. By Week 10 you will have run every defensive practice in the course against one attack surface.
+- The order is the order of a software lifecycle: model, write, ship, scan, harden, sign, detect, triage.
 
 ---
 
-## 📍 Slide 4 – 🍹 The Project: OWASP Juice Shop
+## Slide 4 – The project: OWASP Juice Shop
 
-* 🏗️ Maintained by **Björn Kimminich** since 2014; OWASP Flagship project since 2018
-* 🐛 Ships with **>100 challenges** representing every OWASP Top 10 category and more
-* 🚢 Docker one-liner: `docker run -d -p 3000:3000 bkimminich/juice-shop:v19.0.0`
-* 🎯 **Why Juice Shop is the canonical learning target:**
-  * Realistic stack (Node.js, Angular, SQLite, JWT, file uploads)
-  * Bugs are intentional but **realistic** — not "use eval(user_input)" toy examples
-  * Has a known set of CVEs to find — your scanner output can be checked against ground truth
-* 🧪 Lab 1 deploys it; Labs 4, 5, 7, 8, 10 keep attacking it from different angles
-
-> 💬 *"Juice Shop is a deliberately broken application — but unlike most CTF apps, it's broken in **exactly the way real applications are broken.**"* — Björn Kimminich, OWASP Global AppSec 2022
+- Created by Björn Kimminich in 2014, accepted as an OWASP project in 2016, now an OWASP Flagship project.
+- The course pins v20.0.0 (May 2026). It ships 112 challenges in 16 categories: 16 Sensitive Data Exposure, 13 Injection, 12 Broken Access Control, 12 Improper Input Validation, 9 XSS, 9 Broken Authentication, and so on.
+- Stack: Node.js, Angular, SQLite, JWT sessions, file uploads. The bugs are the kind found in production code, not `eval(user_input)` toys.
+- The score board at `/#/score-board` is ground truth: when a scanner reports a finding in Lab 5, you can check whether it found a known challenge or noise.
+- Lab 1 deploys it. Labs 4, 5, 7, 8 and 10 generate its SBOM, scan its code and its running instance, scan and sign its image, and triage everything in DefectDojo.
 
 ---
 
-## 📍 Slide 5 – 🧭 What Is DevSecOps?
+## Slide 5 – What DevSecOps is
 
-```mermaid
-flowchart LR
-    Dev["👩‍💻 Dev"] -.-> Build["🏗️ Build"]
-    Ops["🖥️ Ops"] -.-> Build
-    Sec["🛡️ Sec"] -.-> Build
-    Build --> DevSecOps["🚀 DevSecOps<br/>Continuous, automated security<br/>at every stage"]
+- January 2012: Gartner analyst Neil MacDonald writes "DevOps Needs to Become DevOpsSec": security has to be built into DevOps workflows rather than bolted on.
+- September 2016: Gartner publishes "DevSecOps: How to Seamlessly Integrate Security Into DevOps" (MacDonald and Head). Security is integrated at multiple points of the pipeline, "largely transparent to developers", without losing the speed of DevOps.
+- Working definition for this course: security controls that run **as code, in the pipeline, at every stage, owned by the team that ships**.
 
-    style DevSecOps fill:#FF9800,color:#fff
-```
-
-* 🧑‍🏫 **Definition** (Gartner, Neil MacDonald, 2012): *"DevSecOps is the practice of integrating security controls and processes into the DevOps approach — automated, transparent, and continuous."*
-* 🪜 **DevOps + a SAST tool ≠ DevSecOps.** The defining shift is *cultural*: security is **everyone's job**, executed **as code**, **early** and **often**
-* 🗓️ The term gained traction at **AWS re:Invent 2015** when teams started publishing pipeline blueprints
-* 📚 First book-length treatment: *"DevOpsSec"* by **Jim Bird** (O'Reilly, 2016)
-* 🚫 **What DevSecOps is NOT:**
-  * Not a tool you buy
-  * Not "the security team approves the pipeline"
-  * Not a one-time audit before launch
-
----
-
-## 📍 Slide 6 – 🕰️ A 25-Year Timeline
-
-| 🗓️ Year | 📍 Milestone |
+| "DevOps plus a scanner" | DevSecOps |
 |---|---|
-| 2001 | Manifesto for Agile Software Development — Snowbird, UT |
-| 2009 | Patrick Debois coins **"DevOps"** at the first DevOpsDays (Ghent, BE) |
-| 2010 | OWASP Top 10 first ranked edition |
-| 2012 | **Gartner** report introduces *DevSecOps* term — Neil MacDonald |
-| 2014 | *More Agile Testing* (Crispin & Gregory) early uses "DevSecOps" in print |
-| 2015 | DevSecOps becomes a track at AWS re:Invent + RSA |
-| 2016 | First book-length treatment — *DevOpsSec* (Jim Bird, O'Reilly) |
-| 2017 | Equifax breach — DevSecOps becomes a boardroom topic |
-| 2020 | SolarWinds — supply-chain security joins the agenda |
-| 2021 | Log4Shell — runtime detection joins the agenda |
-| 2024 | NIST CSF 2.0 adds the *Govern* function |
-| 2025 | **OWASP Top 10:2025** published; supply-chain failures get their own category |
+| One tool, one stage, owned by the security team | Controls at commit, build, deploy and runtime |
+| Findings emailed as a PDF | Findings fail the build or open a ticket with an owner |
+| Security reviews the release | Security writes rules; developers fix in the PR |
+
+- What DevSecOps is not: a product you buy, a security team that approves pipelines, an audit before launch.
 
 ---
 
-## 📍 Slide 7 – 💸 The Cost-of-Defect Curve
+## Slide 6 – Timeline
 
-> 💬 *"The cost of fixing a defect grows roughly 10x at each stage of the SDLC."* — Barry Boehm, *Software Engineering Economics* (Prentice Hall, **1981**)
+| Year | Milestone |
+|---|---|
+| 2001 | Manifesto for Agile Software Development, Snowbird, Utah. OWASP founded. |
+| 2003 | First OWASP Top 10. |
+| 2009 | First DevOpsDays in Ghent, organised by Patrick Debois; the word "DevOps" comes from the event name. |
+| 2012 | Gartner: "DevOps Needs to Become DevOpsSec". |
+| 2016 | Gartner DevSecOps report; Jim Bird, *DevOpsSec* (O'Reilly). |
+| 2017 | Equifax breach. |
+| 2019 | Capital One breach. |
+| 2020 | SolarWinds Orion build compromise (CISA alert AA20-352A, December 2020). |
+| 2021 | Log4Shell. |
+| 2024 | NIST Cybersecurity Framework 2.0 adds the Govern function. |
+| 2025 | OWASP Top 10:2025. |
+
+---
+
+## Slide 7 – A defect costs more the later you find it
+
+- Barry Boehm, *Software Engineering Economics* (1981): on large projects, fixing a defect after delivery cost up to 100 times more than fixing it during requirements.
+- Boehm and Basili, "Software Defect Reduction Top 10 List" (IEEE Computer, 2001): for small, non-critical systems the factor is closer to 5:1. The popular "10x per phase" is a slogan; the direction is what the data supports.
+- NIST, *The Economic Impacts of Inadequate Infrastructure for Software Testing* (2002): software defects cost the US economy about $59.5 billion a year; better testing infrastructure could remove about $22.2 billion of that.
 
 ```mermaid
 graph LR
-    R[📝 Requirements<br/>~$1] --> D[📐 Design<br/>~$10]
-    D --> C[💻 Code<br/>~$100]
-    C --> T[🧪 Testing<br/>~$1000]
-    T --> P[🚨 Production<br/>~$10,000+]
-
+    R["Requirements"] --> D["Design"] --> C["Code"] --> T["Test"] --> P["Production"]
     style R fill:#4CAF50,color:#fff
     style P fill:#F44336,color:#fff
 ```
 
-* 📊 IBM System Sciences (1981) and NIST (2002) studies both confirm the curve. The slope flattens in modern fast-feedback teams, but the **order of magnitude** holds
-* 🎯 **DevSecOps in one diagram:** push every security check **as far left** as it will still produce useful signal
+- DevSecOps in one sentence: run each check at the earliest point where it still produces a useful signal.
 
 ---
 
-## 📍 Slide 8 – ⬅️ Shift-Left, Pragmatically
+## Slide 8 – Shift-left, and where it stops
 
-* 🪜 **Shift-Left** = run security checks earlier in the pipeline, where fixes are cheap
-* ⚠️ But: *"shift-left" doesn't mean "**only** left"* — runtime threats still need runtime defense (Lecture 9)
-* 🪛 **In this course:** every lab maps to a leftward shift of one specific control:
-
-| 🛠️ Control | 📍 Where it shifts to | 🧪 Lab |
+| Control | Where it moves to | Lab |
 |---|---|---|
-| Threat modeling | Design | L2 |
-| Secret leak detection | Pre-commit | L3 |
-| SAST | PR build | L5 |
-| SCA / SBOM | Build | L4 |
-| IaC scanning | PR build | L6 |
-| Image scan | Image build | L7 |
-| Signing/verification | Deploy gate | L8 |
-| Runtime detection | Cluster | L9 |
+| Threat modeling | Design | 2 |
+| Secret detection | Pre-commit hook | 3 |
+| SBOM and dependency scan | Build | 4 |
+| SAST | Pull request | 5 |
+| IaC scanning | Pull request | 6 |
+| Image scan, pod hardening | Image build, deploy | 7 |
+| Signing and verification | Deploy gate | 8 |
+| Runtime detection | Cluster | 9 |
+| Triage, SLAs, metrics | Program | 10 |
 
-* 🧠 The *opposite* of shift-left is "shift-right-only" = a SOC reading post-mortems. Both ends are valid; **the middle is where DevSecOps adds value**
+- Shift-left does not mean only-left. Log4Shell (Slide 15) was unknown to every scanner until December 9, 2021; the teams that coped had runtime detection and an inventory, not a better SAST rule.
+- Labs 9 and 10 exist because some bugs only show up in production.
 
 ---
 
-## 📍 Slide 9 – 🪜 Three Pillars (Culture, Process, Tools)
+## Slide 9 – Culture, process, tools
 
-| 🏛️ Pillar | 🎯 What it means | 🔥 What goes wrong without it |
+| Pillar | What it means | Without it |
 |---|---|---|
-| 👥 **Culture** | Shared accountability; "if a dev wrote it, a dev fixes it" | Security team becomes the bottleneck; devs throw work over the wall |
-| 🛠️ **Process** | Threat modeling, defined SLAs, post-incident reviews | Heroics; same vulns ship every release |
-| 🤖 **Tools** | Automated SAST/DAST/SCA/IaC/runtime in the pipeline | Manual scans = quarterly findings dump nobody reads |
+| Culture | The team that ships owns the fix | Security becomes a queue; findings age |
+| Process | Threat modeling, SLAs per severity, post-incident reviews | The same bug class ships every release |
+| Tools | SAST, DAST, SCA, IaC and runtime checks in the pipeline | Quarterly PDF nobody reads |
 
-* 🪜 The **DORA report** (2022 onward) consistently finds that DevSecOps maturity correlates more with **culture + process** than tool spend
-* 🧪 *"Tools are necessary but not sufficient."* If we only taught tools this course would be 3 weeks long. **It's 10 weeks because process and culture matter more.**
-
----
-
-## 📍 Slide 10 – 🔒 The CIA Triad — and Two Modern Additions
-
-```mermaid
-graph TB
-    CIA[🔐 Classical CIA] --> C[🔏 Confidentiality<br/>only authorized see]
-    CIA --> I[✅ Integrity<br/>only authorized change]
-    CIA --> A[🟢 Availability<br/>authorized always reach]
-    CIA -.modern.-> AU[🪪 Authenticity<br/>identity is real]
-    CIA -.modern.-> NR[📜 Non-Repudiation<br/>can't deny the action]
-
-    style C fill:#2196F3,color:#fff
-    style I fill:#4CAF50,color:#fff
-    style A fill:#FF9800,color:#fff
-```
-
-* 🏛️ **CIA Triad:** classical model, dates to a 1976 US Air Force report (Anderson)
-* 🪪 **Authenticity** matters now because of phishing + AI-generated content
-* 📜 **Non-Repudiation** matters now because of regulatory reporting (GDPR, HIPAA)
-* 🧠 Lab 3 (signed commits) is the first non-repudiation control you'll deploy
+- DORA, *Accelerate State of DevOps 2022* (33,000 respondents): the strongest predictor of adopting security practices is cultural, a high-trust, low-blame culture. Supply-chain security controls improved delivery performance, but only where continuous integration was already in place.
+- This course spends ten weeks rather than three because the tools are the easy part.
 
 ---
 
-## 📍 Slide 11 – 🏆 OWASP and the Top 10:2025
+## Slide 10 – CIA, plus two properties you will implement
 
-* 🌐 **OWASP** = Open Worldwide Application Security Project — community-driven non-profit, **founded 2001**
-* 🏆 The **Top 10** is a periodic ranking of the most critical web app risks. Releases: **2003, 2004, 2007, 2010, 2013, 2017, 2021, 2025**
-* 🆕 **OWASP Top 10:2025** — announced **November 2025**, final release **January 2026** — built on **175,000+ CVE records** + practitioner surveys
-* 🔄 **What's new vs 2021:**
-  * 🆕 **A02: Software Supply Chain Failures** (replaced/expanded "Vulnerable and Outdated Components")
-  * 🆕 **A10: Mishandling of Exceptional Conditions**
-  * 🪜 SSRF absorbed into **Broken Access Control** (it was a category of its own in 2021)
-
----
-
-## 📍 Slide 12 – 🔥 OWASP Top 10:2025 — The List
-
-| # | 🏷️ Category | 🎯 Plain English |
+| Property | Meaning | Where you build it |
 |---|---|---|
-| **A01** | Broken Access Control | Users do things they shouldn't be allowed to (now includes SSRF) |
-| **A02** | **Software Supply Chain Failures** 🆕 | Compromised libs, broken provenance |
-| **A03** | Cryptographic Failures | Weak/missing encryption, hard-coded secrets |
-| **A04** | Injection | SQL, NoSQL, command, LDAP — untrusted input as code |
-| **A05** | Insecure Design | The *architecture* invites the bug |
-| **A06** | Security Misconfiguration | Defaults, debug pages, open S3 buckets |
-| **A07** | Identification & Authentication Failures | Weak passwords, broken MFA, session fixation |
-| **A08** | Software & Data Integrity Failures | Unsigned updates, unsafe deserialization |
-| **A09** | Security Logging & Monitoring Failures | Can't detect because we can't see |
-| **A10** | **Mishandling of Exceptional Conditions** 🆕 | Error paths leak info, fail-open instead of fail-closed |
-
-* 🧠 **Every lab in this course defends against at least one A0X category.** Worth bookmarking this slide
+| Confidentiality | Only authorised parties read the data | Lab 3 (no secrets in Git), Lab 11 (TLS) |
+| Integrity | Only authorised parties change the data or the code | Lab 8 (signed images) |
+| Availability | Authorised parties can reach the system | Lab 11 (rate limiting), Lab 12 (isolation) |
+| Authenticity | The artifact comes from who it claims | Lab 8 (provenance attestations) |
+| Non-repudiation | The author cannot deny the action | Lab 3 (signed commits) |
 
 ---
 
-## 📍 Slide 13 – 💉 Why Injection Hasn't Left the Top 10 in 20 Years
+## Slide 11 – OWASP and the Top 10:2025
+
+- OWASP, the Open Worldwide Application Security Project, is a non-profit founded in 2001. The Top 10 has been published in 2003, 2004, 2007, 2010, 2013, 2017, 2021 and 2025.
+- The 2025 edition is built from data on more than 2.8 million applications contributed by 13 organisations. 589 CWEs were analysed; 248 of them map into the ten categories. Eight categories come from the data, two from the community survey.
+- Changes since 2021:
+  - A03 Software Supply Chain Failures widens the old A06 Vulnerable and Outdated Components to cover the whole build and distribution ecosystem.
+  - A10 Mishandling of Exceptional Conditions is new: error paths that leak information or fail open.
+  - Server-Side Request Forgery, its own category in 2021, is folded into A01 Broken Access Control.
+  - A07 is renamed Authentication Failures; A09 is renamed Security Logging & Alerting Failures.
+
+---
+
+## Slide 12 – The list, and where the course meets each category
+
+| # | Category | In plain terms | Labs |
+|---|---|---|---|
+| A01 | Broken Access Control | Users reach data or actions they should not, including SSRF | 2, 5 |
+| A02 | Security Misconfiguration | Defaults, debug endpoints, missing headers, open buckets | 1, 6, 7 |
+| A03 | Software Supply Chain Failures | Compromised or unverified dependencies, builds, distribution | 4, 8 |
+| A04 | Cryptographic Failures | Weak or missing encryption, secrets in code | 3, 11 |
+| A05 | Injection | Untrusted input executed as SQL, NoSQL, shell, LDAP | 5 |
+| A06 | Insecure Design | The architecture invites the bug | 2 |
+| A07 | Authentication Failures | Weak passwords, broken sessions, missing MFA | 5 |
+| A08 | Software or Data Integrity Failures | Unsigned updates, unsafe deserialisation | 8 |
+| A09 | Security Logging & Alerting Failures | Attacks nobody sees | 9 |
+| A10 | Mishandling of Exceptional Conditions | Stack traces to users, fail-open error paths | 5, 10 |
+
+- Lab 1 asks you to map three observed risks to these categories. Use this table and the OWASP page.
+
+---
+
+## Slide 13 – Why Injection is still on the list after twenty years
 
 ```python
-# ❌ Vulnerable — string concatenation
+# bad: string concatenation
 def get_user(username):
     cursor.execute(f"SELECT * FROM users WHERE name = '{username}'")
-    # Input: bob' OR '1'='1
-    # Becomes: SELECT * FROM users WHERE name = 'bob' OR '1'='1'
+    # input:  bob' OR '1'='1
+    # query:  SELECT * FROM users WHERE name = 'bob' OR '1'='1'
 
-# ✅ Safe — parameterized query
+# good: parameterised query
 def get_user(username):
     cursor.execute("SELECT * FROM users WHERE name = ?", (username,))
 ```
 
-* 🧠 The fix is **trivial** when developers know it. The teaching problem is that **string concat looks fine** until you imagine an attacker
-* 🪜 **Lab 5** (SAST with Semgrep) will catch this exact pattern automatically — your first concrete shift-left win
-* 🎯 OWASP Juice Shop ships **6 SQL injection challenges** as of v19; you'll find them with Semgrep before you find them by hand
+- The fix is one line once you see it. The problem is that the first version looks fine until you think like an attacker.
+- Juice Shop v20.0.0 has 13 Injection challenges (SQL and NoSQL). In Lab 5, Semgrep flags the vulnerable patterns in the source before you find them by hand.
 
 ---
 
-## 📍 Slide 14 – 🔬 Case Study: Capital One (2019)
+## Slide 14 – Case study: Capital One, 2019
 
-* 🗓️ **July 19, 2019** — Paige Thompson (former AWS employee) exploits a **misconfigured WAF** at Capital One via **SSRF**
-* 🪜 The WAF's IAM role had wildcard `s3:Get*` / `s3:List*` across **700+ buckets**
-* 💾 Exfiltration: **106 million records**, 140,000 SSNs
-* 💰 Settlement: **$190M**
-* 🧠 **The lessons in DevSecOps terms:**
-  * 🏗️ **IaC scan** (L6) would have flagged the wildcard IAM
-  * 🎯 **Threat modeling** (L2) would have surfaced the metadata service as a trust boundary
-  * 📊 **Runtime detection** (L9) on outbound S3 calls would have caught the exfiltration mid-flight
+- A former AWS employee sent Server-Side Request Forgery requests through a misconfigured open-source web application firewall running on an EC2 instance. The WAF fetched the EC2 instance metadata service and returned the instance role's temporary credentials.
+- Those credentials could list and read more than 700 S3 buckets. About 106 million credit applications were taken, including about 140,000 Social Security numbers and 80,000 bank account numbers.
+- Consequences: an $80 million civil penalty from the OCC (2020), a $190 million class-action settlement, and a federal conviction for the attacker (2022).
+- In course terms: an IaC scan (Lab 6) flags an instance role with wildcard S3 permissions; a threat model (Lab 2) marks the metadata service as a trust boundary; runtime detection (Lab 9) sees a WAF host suddenly reading S3. In OWASP Top 10:2025 numbering this is A01, since SSRF now lives there.
 
 ---
 
-## 📍 Slide 15 – 🔬 Case Study: Log4Shell (2021)
+## Slide 15 – Case study: Log4Shell, 2021
 
-* 🗓️ **November 24, 2021** — Alibaba security team discloses CVE-2021-44228 (CVSS 10.0) in **Log4j 2**
-* 🌍 **Log4j is everywhere** — embedded in millions of Java apps, including Minecraft, iCloud, Steam, Tesla
-* 🐛 The bug: log messages are interpreted as JNDI lookups → arbitrary code execution from a log line
-* 🐍 December 9, 2021: PoC goes public. The internet rewrites Christmas plans
-* 🧠 **In DevSecOps terms:**
-  * 📋 **SBOM** (L4) — could you instantly say *"do my services depend on Log4j 2?"* Most companies couldn't on day one
-  * 🔏 **Supply-chain signing** (L8) — verifying provenance doesn't fix vuln deps, but it lets you know *which exact version* you have, fast
-  * 📊 **Runtime detection** (L9) — Falco rules for unusual JNDI lookups shipped within 24 hours
-
-> 🤔 **Think:** Log4Shell was a code-level bug, but every defense that worked was at a **higher** layer (SBOM, runtime detection). What does that tell you about defense-in-depth?
+- November 24, 2021: Chen Zhaojun of Alibaba Cloud reports CVE-2021-44228 to the Apache Logging project. December 6: a fix appears in 2.15.0-rc1. December 9: the bug is public and exploited within hours. CVSS 10.0.
+- The bug: Log4j 2 resolves `${jndi:ldap://...}` inside a log message, so any logged user input can load and run remote code.
+- Log4j is embedded in a large share of Java software, so the first question everywhere was "which of our services contain log4j-core, and which version?"
+- In course terms: an SBOM (Lab 4) answers that question in minutes instead of days; dependency scanning (Lab 4) flags the vulnerable version; runtime detection (Lab 9) catches the outbound LDAP connection from a service that never makes one.
 
 ---
 
-## 📍 Slide 16 – 🧩 Secure SDLC: The Five Phases
+## Slide 16 – Secure SDLC: where each lab sits
 
-```mermaid
-flowchart LR
-    R[📝 Requirements] --> D[📐 Design]
-    D --> I[💻 Implement]
-    I --> V[🧪 Verify]
-    V --> O[🚀 Operate]
-    O -.feedback.-> R
-
-    style R fill:#FF9800,color:#fff
-    style D fill:#9C27B0,color:#fff
-    style I fill:#2196F3,color:#fff
-    style V fill:#4CAF50,color:#fff
-    style O fill:#F44336,color:#fff
-```
-
-| 🪜 Phase | 🛡️ DevSecOps practice | 🧪 Lab |
+| Phase | Practice | Labs |
 |---|---|---|
-| Requirements | Security stories, abuse cases | (Lecture-only) |
-| Design | Threat modeling (STRIDE), data classification | **L2** |
-| Implement | Signed commits, secret scanning, secure coding | **L3** |
-| Verify | SAST, DAST, IaC scan, container scan, SBOM/SCA | **L4–L8** |
-| Operate | Runtime detection, vuln management, metrics | **L9–L10** |
+| Requirements | Abuse cases, security stories | lecture only |
+| Design | Threat modeling with STRIDE, trust boundaries | 2 |
+| Implement | Signed commits, secret scanning | 3 |
+| Verify | SBOM, SCA, SAST, DAST, IaC and image scanning, signing | 4 to 8 |
+| Operate | Runtime detection, vulnerability management, metrics | 9, 10 |
 
-* 🪜 **The whole point of this course is that practice goes in each phase** — by Week 10 you'll have something running in every one
-
----
-
-## 📍 Slide 17 – 🪜 Maturity Models — Where You'll End Up
-
-* 🏛️ **OWASP SAMM** — *Software Assurance Maturity Model* — 4 levels × 15 practices. We'll do a proper walkthrough in Lecture 9
-* 📊 **BSIMM** — *Building Security In Maturity Model* — descriptive, annual report (BSIMM 16 in January 2026, based on 111 orgs)
-* 🪜 A typical org distribution (2026 BSIMM data):
-  * Level 0: <10% (no formal program)
-  * Level 1: ~40% (ad-hoc, person-dependent)
-  * Level 2: ~40% (documented, repeatable)
-  * Level 3: ~10% (measured, continuously improved)
-* 🎯 **End-of-course goal:** every student should be able to **describe a Level 2 program** and identify *one concrete gap* to push their team toward Level 3 — this is exam-territory material
+- NIST SP 800-218, the Secure Software Development Framework, is the reference standard for this table; Lecture 9 returns to it.
 
 ---
 
-## 📍 Slide 18 – 🏢 Roles in a DevSecOps Team
+## Slide 17 – Maturity models and roles
 
-| 🧑‍💼 Role | 🎯 Responsibility | 👀 Where you meet them in the course |
+- OWASP SAMM (Software Assurance Maturity Model): 15 security practices, each scored at maturity level 1 (initial), 2 (structured, repeatable) or 3 (optimised, measured). Lecture 9 walks through it.
+- BSIMM (Building Security In Maturity Model, Black Duck): an annual descriptive study of what real programs do, useful for benchmarking.
+- Moving from level 1 to level 2 in SAMM terms means documenting what already happens and making it repeat every release, not buying a tool.
+
+| Role | Owns | In this course |
 |---|---|---|
-| 👩‍💻 **Developer** | Writes code, runs SAST locally, fixes findings | Every lab |
-| 🚀 **DevOps/SRE** | Maintains the pipeline; deploys hardening | L4, L7 |
-| 🛡️ **Security Engineer** | Writes detection rules, custom policies | L6, L9 |
-| 🦸 **Security Champion** | Developer trained in security; embeds in dev teams | Lecture-only |
-| 🎯 **Security Architect** | Designs trust boundaries, signs off threat models | L2 |
-| 📊 **Security Manager** | Owns metrics, SLAs, exec reporting | L10 |
+| Developer | Writes code, fixes findings in the PR | every lab |
+| DevOps / SRE | Pipeline, deploy hardening | 4, 7 |
+| Security engineer | Detection rules, custom policies | 6, 9 |
+| Security champion | A developer with security training, embedded in a product team, reviews PRs | lecture only |
+| Security manager | SLAs, metrics, reporting | 10 |
 
-* 🪜 **"Security Champion" is the role that scales DevSecOps in real orgs** — one developer per team trained to push back on PRs that ship vulnerable code. Read the OWASP Security Champions Playbook (v2.0, 2024) when you have a quiet hour
-
----
-
-## 📍 Slide 19 – 🚫 The Five Myths You'll Hear at Your First Job
-
-| 😱 Myth | 🧠 Reality |
-|---|---|
-| *"Security slows us down"* | DORA 2024: high-performing security teams ship **more often** than low-performing ones |
-| *"We'll do security after MVP"* | The MVP becomes legacy; security tech debt compounds at 1.7x/year |
-| *"We have a firewall"* | Modern apps speak HTTPS through firewalls; perimeter security is a 1990s mental model |
-| *"Our scanner shows 0 critical, so we're secure"* | Scanners find *known* bugs. Your unknowns are your unknowns. (Threat modeling, L2) |
-| *"That's the security team's problem"* | The security team can't be in every PR. Distributed ownership is the only model that scales |
-
-* 🧠 You'll hear at least three of these in the first month of any real DevSecOps job. The point of this course is to give you the data + stories to push back without sounding theoretical
+- The OWASP Security Champions Guide describes how to start a champions program; it is the role that scales DevSecOps beyond the security team.
 
 ---
 
-## 📍 Slide 20 – 📚 Resources & What's Next
+## Slide 18 – Five things you will hear at your first job
 
-**Books to keep on your desk:**
-
-| 📖 Book | ✍️ Why |
+| Claim | What the evidence says |
 |---|---|
-| *DevOpsSec* — Jim Bird (O'Reilly, 2016, free PDF) | Still the most accessible DevSecOps overview; 80 pages |
-| *Securing DevOps* — Julien Vehent (Manning, 2018) | Real Mozilla pipeline walkthrough; ch. 2 maps tools to phases |
-| *The DevOps Handbook* — Kim, Humble, Debois, Willis (2nd ed., 2021) | The DevOps cultural foundation that DevSecOps extends |
-| *Web Application Security* — Andrew Hoffman (O'Reilly, 2020) | Companion to Juice Shop attacks; ch. 4 maps to A03/A07 |
+| "Security slows us down" | DORA 2022: supply-chain security controls improved delivery performance where CI was in place |
+| "We'll add security after the MVP" | Boehm: the later the fix, the higher the cost; the MVP becomes the legacy system |
+| "We have a firewall" | Capital One had a WAF; the WAF was the entry point. Modern traffic is HTTPS through port 443 and the perimeter says nothing about the application |
+| "The scanner shows zero criticals" | Scanners find known patterns; on December 8, 2021 every scanner showed zero Log4Shell findings |
+| "That's the security team's problem" | Equifax security sent the directive; the team that ran the portal never saw it. Ownership sits with the team that runs the system |
 
-**Talks (1–2 hours, worth your time):**
+---
 
-* 🎥 *"Continuous Delivery + DevSecOps: The Marriage"* — Jez Humble, GOTO 2019
-* 🎥 *"How Mozilla Does DevSecOps"* — Julien Vehent, AppSec EU 2018
-* 🎥 *"OWASP Top 10:2025 — What Changed and Why"* — Andrew van der Stock (OWASP), Global AppSec 2025
+## Slide 19 – Lab 1, next lecture, reading
 
-**Standards & specs (bookmark them):**
+Lab 1 this week:
+- Task 1 (6 pts): run Juice Shop v20.0.0 on localhost, write a triage report, map three risks to the Top 10:2025.
+- Task 2 (3 pts): a PR template your fork uses for every lab.
+- Task 3 (1 pt): GitHub community engagement.
+- Bonus (2 pts): a GitHub Actions smoke test of Juice Shop; a preview of Lecture 4.
 
-* 📜 [OWASP Top 10:2025](https://owasp.org/Top10/2025/)
-* 📜 [OWASP Juice Shop](https://owasp.org/www-project-juice-shop/)
-* 📜 [NIST SSDF (SP 800-218)](https://csrc.nist.gov/Projects/ssdf) — the canonical secure-SDLC standard
+Next week: Lecture 2, threat modeling with STRIDE and Threagile. Bring a diagram of any system you have worked on.
 
-**Next week:** Lecture 2 — **Threat Modeling with STRIDE and Threagile**. Bring a system diagram of any app you've worked on; we'll model it.
+Books:
+- Jim Bird, *DevOpsSec* (O'Reilly, 2016). Short, free, the clearest overview of the idea.
+- Julien Vehent, *Securing DevOps* (Manning, 2018). A real pipeline at Mozilla, tool by tool.
+- Kim, Humble, Debois, Willis, *The DevOps Handbook*, 2nd ed. (IT Revolution, 2021). The cultural foundation DevSecOps extends.
+- Andrew Hoffman, *Web Application Security*, 2nd ed. (O'Reilly, 2024). Companion to the attacks Juice Shop contains.
 
-> 💬 *"Security is not a product, but a process."* — Bruce Schneier, *Secrets and Lies* (Wiley, 2000) — and still true 26 years later.
+Talks: Julien Vehent, "Beyond the Security Team" (DevSecCon Seattle, 2019); Vehent, "Tools & Techniques from Building a DevSecOps Culture at Mozilla" (SBA Live Academy, 2020).
+
+> "Security is a process, not a product." Bruce Schneier, *Information Security Magazine*, April 2000.
+
+---
+
+## Sources
+
+- Equifax timeline, root causes: US House Committee on Oversight, *The Equifax Data Breach* (Dec 2018), https://oversight.house.gov/wp-content/uploads/2018/12/Equifax-Report.pdf ; CSO Online FAQ, https://www.csoonline.com/article/567833/equifax-data-breach-faq-what-happened-who-was-affected-what-was-the-impact.html
+- Equifax settlement (up to $700M): FTC, https://www.ftc.gov/enforcement/refunds/equifax-data-breach-settlement
+- Gartner 2012 blog: https://blogs.gartner.com/neil_macdonald/2012/01/17/devops-needs-to-become-devopssec/ ; Gartner 2016 report: https://www.gartner.com/en/documents/3463417
+- Jim Bird, *DevOpsSec*: https://www.oreilly.com/library/view/devopssec/9781491971413/
+- Agile Manifesto history: https://agilemanifesto.org/history.html ; DevOpsDays Ghent 2009: https://devopsdays.org/events/2009-ghent/
+- OWASP Top 10 project and editions: https://owasp.org/www-project-top-ten/ ; Top 10:2025 list and introduction (data figures, changes): https://owasp.org/Top10/2025/ , https://owasp.org/Top10/2025/0x00_2025-Introduction/
+- NIST CSF 2.0: https://www.nist.gov/cyberframework ; SolarWinds, CISA AA20-352A: https://www.cisa.gov/news-events/cybersecurity-advisories/aa20-352a
+- Boehm and Basili 2001: https://www.cs.umd.edu/projects/SoftEng/ESEG/papers/82.78.pdf ; NIST 2002 software testing study: https://www.rti.org/sites/default/files/resources/software_testing.pdf
+- DORA 2022 report: https://dora.dev/research/2022/dora-report/
+- Capital One: DOJ conviction release (2022), https://www.justice.gov/usao-wdwa/pr/former-seattle-tech-worker-convicted-wire-fraud-and-computer-intrusions ; OCC $80M penalty (2020), https://www.occ.gov/news-issuances/news-releases/2020/nr-occ-2020-101.html
+- Log4Shell: Apache Logging security page, https://logging.apache.org/security.html ; CISA alert, https://www.cisa.gov/news-events/alerts/2021/12/10/apache-releases-log4j-version-2150-address-critical-rce-vulnerability ; Datadog timeline, https://www.datadoghq.com/blog/log4j-log4shell-vulnerability-overview-and-remediation/
+- OWASP SAMM: https://owaspsamm.org/model/ ; BSIMM: https://www.blackduck.com/services/security-program/bsimm-maturity-model.html ; OWASP Security Champions Guide: https://owasp.org/www-project-security-champions-guidebook/
+- NIST SSDF SP 800-218: https://csrc.nist.gov/Projects/ssdf
+- Juice Shop project: https://owasp.org/www-project-juice-shop/ ; v20.0.0 release and challenge list: https://github.com/juice-shop/juice-shop/releases/tag/v20.0.0
+- Books: https://www.manning.com/books/securing-devops , https://itrevolution.com/product/the-devops-handbook-second-edition/ , https://www.oreilly.com/library/view/web-application-security/9781098143923/
+- Talks: http://jvehent.org/2019/09/30/beyond_the_security_team.html , https://www.slideshare.net/SBA-Research/tools-amp-techniques-building-a-dev-secops-culture-at-mozilla-sba-live-academy-may-2020-234913386
+- Schneier, "The Process of Security" (2000): https://www.schneier.com/essays/archives/2000/04/the_process_of_secur.html


### PR DESCRIPTION
## Why

Student feedback across the 2026 cohorts came down to three things: too much text per lab, commands that fail, and facts or citations that do not hold up. This PR sets the new standard on Lecture 1 and Lab 1. The remaining lectures and labs follow in separate PRs.

## Lecture 1

Slide format is unchanged (20 slides, same style). Changes are factual only:

- Every date, number, quote, book and talk now has a URL in a new `Sources` section. Claims that could not be sourced were removed: the "Kimminich, Global AppSec 2022" quote, the Gartner 2012 "definition" quote, the "Jez Humble, GOTO 2019" and "van der Stock, Global AppSec 2025" talks, BSIMM level percentages, "security debt compounds 1.7x/year", "DORA 2024: security teams ship more often", the 1976 CIA-triad date, "6 SQL injection challenges", "AWS re:Invent 2015", "Falco rules shipped within 24 hours".
- Corrections:
  - OWASP Top 10:2025 order: A02 is Security Misconfiguration and A03 is Software Supply Chain Failures (the old slide had them swapped); data figures are 2.8M+ applications from 13 organisations and 589/248 CWEs, not "175k CVE records"; A07/A09 renames added.
  - DevSecOps origin: MacDonald's January 2012 "DevOps Needs to Become DevOpsSec" blog and the September 2016 Gartner DevSecOps report.
  - Boehm's cost curve stated as Boehm reports it (up to 100:1 on large projects, closer to 5:1 on small ones) instead of "10x per stage"; NIST 2002 figures added.
  - Juice Shop: v20.0.0, 112 challenges, 13 Injection (from its `challenges.yml`); the docker one-liner now binds to 127.0.0.1 like the lab does.
  - Capital One: OCC penalty and conviction added; Schneier quote attributed to its actual venue.

## Lab 1

- 2537 -> 1178 words. Tasks, points, deliverables and acceptance criteria are unchanged, so submissions already in flight are graded the same way.
- Dropped: Overview, Project State, Rubric table (it duplicated the acceptance criteria), PR checklist (the PR template does this), Looking ahead, and the per-task report scaffolds (replaced by a short Submit list per task).
- Fixed: image digest now comes from `RepoDigests` (`{{.Image}}` is the local image ID, not a digest); `/rest/products` documented as returning 500 in v20 with `/rest/admin/application-version` as the health check; missing security headers mapped to A02:2025 Security Misconfiguration (was A06, the 2021 number); slide-number references replaced with topic references.
- Every command was executed against `bkimminich/juice-shop:v20.0.0` before opening this PR: HTTP 200, `{"version":"20.0.0"}`, 46 products, digest `sha256:fd58bdc9...`, headers as listed in the lab.

## README

- OWASP 2025 data figure corrected, unverified talk removed, Juice Shop line trimmed to verified facts (Node 24, 112 challenges, prompt-injection challenge).

## Quiz

The Lecture 1 quiz questions on the DevSecOps origin, DORA, Boehm and the OWASP 2025 changes were updated to match, in EN and RU.

## Follow-ups (separate PRs)

- Same treatment for lectures 2-10, readings 11-12 and labs 2-12.
- Re-pin the tool stack for the fall semester (Juice Shop 20.2.0, Semgrep 1.176, Trivy 0.74, Falco 0.44, Cosign 3.1, k3d 5.9; DefectDojo is now 3.x, so the Lab 10 importer needs re-verification).
- A "lab bug" issue template.
