### PR TITLE
chore(tools): add the checks that would have caught this session's own mistakes

### DIFF
--- a/.github/workflows/course-health.yml
+++ b/.github/workflows/course-health.yml
@@ -20,6 +20,11 @@ jobs:
       issues: write
     steps:
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+      - name: Shellcheck the shipped scripts
+        run: |
+          sudo apt-get install -y --no-install-recommends shellcheck >/dev/null
+          shellcheck -S warning $(git ls-files 'labs/**/*.sh' 'tools/*.sh')
+
       - name: Check pinned versions against upstream
         id: check
         env:
@@ -34,6 +39,9 @@ jobs:
           set -e
           cat report.txt
           echo "drift=$drift" >> "$GITHUB_OUTPUT"
+      - name: Course consistency checks
+        run: python3 tools/check-course.py
+
       - name: Open or update the drift issue
         if: steps.check.outputs.drift != '0'
         env:

--- a/README.md
+++ b/README.md
@@ -121,7 +121,7 @@ The course repo ships **only** lab specs, lecture notes, and plumbing files. Stu
 | `labs/lab10/imports/` — DefectDojo importer | ✅ | |
 | `labs/lab11/docker-compose.yml`, `labs/lab11/reverse-proxy/nginx.conf` | ✅ | |
 | `labs/lab12/scripts/` — Kata install/configure | ✅ | |
-| `tools/` — version manifest + drift and lab checkers | ✅ | |
+| `tools/` — version manifest, drift, consistency and lab checkers | ✅ | |
 | `.github/workflows/course-health.yml`, `.github/ISSUE_TEMPLATE/` | ✅ | |
 | `.github/PULL_REQUEST_TEMPLATE.md` — students write in Lab 1 | | ✅ |
 | `.github/workflows/*.yml` — students add from Lab 1 bonus onward | | ✅ |
@@ -291,6 +291,7 @@ DevSecOps-Intro/
 ├── tools/                         # Course maintenance (ships)
 │   ├── versions.yaml              #   every pinned tool version, one source of truth
 │   ├── check-versions.py          #   compares the pins with upstream releases
+│   ├── check-course.py            #   cross-lab handoffs, versions, structure, coverage
 │   └── verify-lab.sh              #   runs every shell block of a lab spec
 │
 ├── refs/                          # Instructor reference submissions (gitignored)

--- a/labs/lab2.md
+++ b/labs/lab2.md
@@ -111,6 +111,7 @@ Note the output directory is `labs/lab2/output-secure`, not a directory inside `
 
 Build a second, smaller model covering only Juice Shop's login path: browser, login endpoint, token issuing and verification, the credential store, an admin endpoint. Start from a skeleton, not from the baseline model:
 
+<!-- produces: labs/lab2/threagile-stub-model.yaml by threagile -create-stub-model -->
 ```bash
 mkdir -p labs/lab2/output-auth
 docker run --rm -v "$(pwd)/labs/lab2":/app/work \

--- a/labs/lab4.md
+++ b/labs/lab4.md
@@ -30,6 +30,8 @@ mkdir -p labs/lab4
 
 ### 4.1 Generate two SBOMs
 
+<!-- produces: labs/lab4/juice-shop.cdx.json for lab 8 and lab 10 -->
+<!-- produces: labs/lab4/grype-from-sbom.json for lab 10 -->
 ```bash
 syft bkimminich/juice-shop:v20.0.0 -o cyclonedx-json=labs/lab4/juice-shop.cdx.json
 syft bkimminich/juice-shop:v20.0.0 -o spdx-json=labs/lab4/juice-shop.spdx.json

--- a/labs/lab5.md
+++ b/labs/lab5.md
@@ -51,6 +51,7 @@ Two to three minutes. It ends with a `FAIL-NEW / WARN-NEW / PASS` line and exits
 
 ### 5.2 Authenticated full scan
 
+<!-- produces: labs/lab5/results/auth-report.json for lab 10 -->
 <!-- verify:skip a 10-20 minute active scan; run it by hand -->
 ```bash
 docker run --rm --network lab5-net -e _JAVA_OPTIONS="-Xmx512m" \
@@ -91,6 +92,7 @@ Pin the clone to the container's tag: scanning `main` while attacking v20.0.0 ma
 
 ### 5.5 Scan
 
+<!-- produces: labs/lab5/results/semgrep.json for lab 10 -->
 <!-- verify:skip needs the clone from 5.4 and takes several minutes -->
 ```bash
 semgrep --config=p/owasp-top-ten --config=p/javascript --config=p/secrets \

--- a/labs/lab6.md
+++ b/labs/lab6.md
@@ -70,6 +70,7 @@ Checkov 3.x has no Pulumi framework: it wants rendered state, not Python. KICS p
 
 ### 6.3 Scan both
 
+<!-- produces: labs/lab6/results/kics-ansible/results.json for lab 10 -->
 <!-- verify:nonzero-ok kics exits non-zero when it finds anything -->
 ```bash
 docker run --rm --user "$(id -u):$(id -g)" -v "$(pwd)/labs/lab6":/path \
@@ -77,6 +78,7 @@ docker run --rm --user "$(id -u):$(id -g)" -v "$(pwd)/labs/lab6":/path \
   -o /path/results/kics-ansible/ --report-formats json,sarif
 ```
 
+<!-- produces: labs/lab6/results/kics-pulumi/results.json for lab 10 -->
 <!-- verify:nonzero-ok kics exits non-zero when it finds anything -->
 ```bash
 docker run --rm --user "$(id -u):$(id -g)" -v "$(pwd)/labs/lab6":/path \

--- a/labs/lab7.md
+++ b/labs/lab7.md
@@ -141,6 +141,8 @@ The namespace goes first on purpose. `kubectl apply -f <dir>` processes files in
 
 ### 7.6 Scan the running workload
 
+<!-- produces: labs/lab7/results/trivy-image.json for lab 10 -->
+<!-- produces: labs/lab7/results/trivy-k8s.json for lab 10 -->
 <!-- verify:skip needs the cluster and the deployment from 7.5 -->
 ```bash
 kubectl create ns juice-plain

--- a/tools/check-course.py
+++ b/tools/check-course.py
@@ -1,0 +1,232 @@
+#!/usr/bin/env python3
+"""Consistency checks across a course repository.
+
+Usage:  python3 tools/check-course.py [--quiet]
+
+Checks, in order of how much breakage each one has actually caught:
+
+  handoffs   a lab reads a file no earlier lab produces and that is not shipped
+  plumbing   a shipped file under labs/labN/ that no lab spec mentions
+  versions   a version string in a lab or the README that disagrees with
+             tools/versions.yaml
+  structure  missing sections, point totals that do not add up
+  coverage   a task with no matching line in Acceptance criteria
+
+Exit code 1 if anything is reported, so CI can act on it.
+"""
+import os
+import re
+import subprocess
+import sys
+
+ROOT = os.path.dirname(os.path.dirname(os.path.abspath(__file__)))
+LABS = os.path.join(ROOT, "labs")
+problems = []
+
+
+def report(check, where, msg):
+    problems.append((check, where, msg))
+
+
+def lab_files():
+    out = []
+    for name in sorted(os.listdir(LABS)):
+        m = re.fullmatch(r"lab(\d+)\.md", name)
+        if m:
+            out.append((int(m.group(1)), os.path.join(LABS, name)))
+    return sorted(out)
+
+
+def tracked_files():
+    try:
+        res = subprocess.run(["git", "ls-files", "labs"], cwd=ROOT,
+                             capture_output=True, text=True, check=True)
+    except Exception:
+        return []
+    return [p for p in res.stdout.split("\n") if p]
+
+
+WRITE_RE = re.compile(
+    r"(?:--output(?:-file-path)?[= ]+|--file[= ]+|-o[= ]+|tee\s+|>\s*|mv\s+\S+\s+|cp\s+\S+\s+)"
+    r"(labs/lab\d+/[\w./-]+)")
+PATH_RE = re.compile(r"labs/lab\d+/[\w./-]+\.\w+")
+# A path the student is told to create: it appears in a YOUR TASK scaffold, or as
+# the header comment of one. Those are not handoffs and have no producer.
+STUDENT_RE = re.compile(r"#\s*(labs/lab\d+/[\w./-]+\.\w+)")
+# Escape hatch for a file this script cannot see being produced, for example one
+# a container writes into a mounted directory. Put it in the lab spec:
+#   <!-- produces: labs/lab2/threagile-stub-model.yaml by threagile -create-stub-model -->
+PRODUCES_RE = re.compile(r"<!--\s*produces:\s*(labs/lab\d+/[\w./-]+)")
+
+
+def check_handoffs_and_plumbing(labs):
+    """Cross-lab handoffs only.
+
+    A path within one lab is that lab's own business: verify-lab.sh runs those
+    commands. What breaks silently is a *later* lab, or a shipped script, reading
+    a file an *earlier* lab was supposed to produce. Those must be declared:
+
+        <!-- produces: labs/lab7/results/trivy-k8s.json for lab 10 -->
+
+    Declaring it is the point. The alternative is a regex that tries to
+    recognise every way a tool can be told to write a file, which is how a
+    dropped handoff went unnoticed until the importer ran.
+    """
+    shipped = set(tracked_files())
+    produced = {}
+    for num, path in labs:
+        text = open(path).read()
+        for p in PRODUCES_RE.findall(text):
+            produced[p.rstrip("/")] = num
+        for p in WRITE_RE.findall(text):
+            produced.setdefault(p.rstrip("/"), num)
+        for d in re.findall(r"(?:--output-file-path|-o)[= ]+(labs/lab\d+/[\w./-]*/)", text):
+            produced.setdefault(d.rstrip("/") + "/*", num)
+
+    def has_producer(p, by_lab):
+        if p in shipped:
+            return True
+        owner = produced.get(p)
+        if owner is not None and owner <= by_lab:
+            return True
+        for d, lab in produced.items():
+            if d.endswith("/*") and p.startswith(d[:-1]) and lab <= by_lab:
+                return True
+        return False
+
+    referenced = set()
+    for num, path in labs:
+        text = open(path).read()
+        name = os.path.basename(path)
+        for p in sorted(set(PATH_RE.findall(text))):
+            referenced.add(p)
+            m = re.match(r"labs/lab(\d+)/", p)
+            if not m or int(m.group(1)) == num:
+                continue                      # same lab: its own business
+            if not has_producer(p, num):
+                report("handoffs", name,
+                       f"reads {p} from lab{m.group(1)}, which nothing declares as produced")
+
+    for rel in sorted(shipped):
+        if rel.endswith(".md"):
+            continue
+        m = re.search(r"labs/lab(\d+)/", rel)
+        if not m:
+            continue
+        owner = int(m.group(1))
+        try:
+            body = open(os.path.join(ROOT, rel)).read()
+        except (OSError, UnicodeDecodeError):
+            continue
+        for p in sorted(set(PATH_RE.findall(body))):
+            referenced.add(p)
+            pm = re.match(r"labs/lab(\d+)/", p)
+            if not pm or int(pm.group(1)) == owner:
+                continue
+            if not has_producer(p, owner):
+                report("handoffs", rel,
+                       f"reads {p}, which nothing declares as produced")
+
+    all_text = "\n".join(open(path).read() for _, path in labs)
+    for p in sorted(shipped):
+        if p.endswith(".md") or p in referenced:
+            continue
+        if os.path.basename(p) in all_text:
+            continue
+        parent = os.path.dirname(p)
+        covered = False
+        while parent and parent != "labs":
+            if parent in all_text or parent + "/" in all_text:
+                covered = True
+                break
+            parent = os.path.dirname(parent)
+        if not covered:
+            report("plumbing", p, "shipped but no lab spec mentions it")
+
+
+VERSION_HINTS = {
+    "juice-shop": r"juice-shop:v(\d+\.\d+\.\d+)",
+    "threagile": r"threagile:v?(\d+\.\d+\.\d+)",
+    "cosign": r"[Cc]osign v?(\d+\.\d+)",
+    "trivy": r"[Tt]rivy v?(\d+\.\d+)",
+    "falco": r"falco:(\d+\.\d+\.\d+)",
+    "defectdojo": r"--branch (\d+\.\d+\.\d+)",
+    "kata": r"[Kk]ata (?:Containers )?v?(\d+\.\d+)",
+    "k3d": r"k3s v?(\d+\.\d+)",
+}
+
+
+def check_versions(labs):
+    try:
+        import yaml
+    except ImportError:
+        report("versions", "tools/versions.yaml", "PyYAML missing; skipped")
+        return
+    manifest = yaml.safe_load(open(os.path.join(ROOT, "tools", "versions.yaml")))
+    files = [(os.path.basename(p), p) for _, p in labs]
+    files.append(("README.md", os.path.join(ROOT, "README.md")))
+    for tool, spec in manifest.get("tools", {}).items():
+        pat = VERSION_HINTS.get(tool)
+        if not pat:
+            continue
+        pin = str(spec.get("k8s") or spec.get("pin", "")).lstrip("v")
+        for name, path in files:
+            for found in set(re.findall(pat, open(path).read())):
+                if not pin.startswith(found) and not found.startswith(pin.split(".")[0] + "."):
+                    report("versions", name,
+                           f"{tool} appears as {found}, manifest pins {pin}")
+                elif not pin.startswith(found):
+                    report("versions", name,
+                           f"{tool} appears as {found}, manifest pins {pin}")
+
+
+REQUIRED_SECTIONS = ["## Setup", "## Task 1", "## Submit",
+                     "## Acceptance criteria", "## Common pitfalls", "## Resources"]
+
+
+def check_structure_and_coverage(labs):
+    for num, path in labs:
+        text = open(path).read()
+        name = os.path.basename(path)
+        for section in REQUIRED_SECTIONS:
+            if section not in text:
+                report("structure", name, f"missing section {section}")
+        points = [int(x) for x in re.findall(r"^## (?:Task \d+|Bonus).*\((\d+) pts?\)",
+                                             text, re.M)]
+        if points:
+            total = sum(points)
+            expected = 12 if num <= 10 else 10
+            if total != expected:
+                report("structure", name,
+                       f"task points add up to {total}, expected {expected}")
+        tasks = re.findall(r"^## (Task \d+|Bonus)", text, re.M)
+        acc = text.split("## Acceptance criteria", 1)
+        if len(acc) == 2:
+            acc_text = acc[1].split("\n## ", 1)[0].lower()
+            for t in tasks:
+                key = t.lower()
+                if key not in acc_text:
+                    report("coverage", name,
+                           f"{t} has no line in Acceptance criteria")
+
+
+def main():
+    labs = lab_files()
+    if not labs:
+        sys.exit("no labs found under " + LABS)
+    check_handoffs_and_plumbing(labs)
+    check_versions(labs)
+    check_structure_and_coverage(labs)
+
+    if not problems:
+        print("check-course: %d labs, nothing to report" % len(labs))
+        return 0
+    width = max(len(c) for c, _, _ in problems)
+    for check, where, msg in problems:
+        print("%-*s  %-14s %s" % (width, check, where, msg))
+    print("\n%d problem(s)" % len(problems))
+    return 1
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/tools/verify-lab.sh
+++ b/tools/verify-lab.sh
@@ -90,12 +90,14 @@ while IFS="$(printf '\t')" read -r n start marker; do
   fi
   printf "  %2s  line %-5s RUN   %s\n" "$n" "$start" "$first"
   ran=$((ran + 1))
-  if ( cd "$ROOT" && bash -eo pipefail "$file" ) > "$WORK/out-$n.log" 2>&1; then
+  ( cd "$ROOT" && bash -eo pipefail "$file" ) > "$WORK/out-$n.log" 2>&1
+  status=$?
+  if [ "$status" -eq 0 ]; then
     printf "      ok\n"
   elif [ -n "$nonzero_ok" ]; then
-    printf "      ok (non-zero exit, expected)\n"
+    printf "      ok (non-zero exit %s, expected)\n" "$status"
   else
-    printf "      FAILED (exit %s), last lines:\n" "$?"
+    printf "      FAILED (exit %s), last lines:\n" "$status"
     tail -5 "$WORK/out-$n.log" | cut -c1-160 | sed 's/^/      | /'
     failed=$((failed + 1))
     break

--- a/tools/versions.yaml
+++ b/tools/versions.yaml
@@ -99,6 +99,7 @@ tools:
 
   k3d:
     pin: v5.9.0
+    k8s: "1.33"          # the k3s version lab 7 runs; checked by check-course.py
     labs: [7]
     github: k3d-io/k3d
     verified: recorded


### PR DESCRIPTION
Three more courses are getting this treatment, so I went back over the mistakes **I** made during the DevSecOps-Intro pass and turned each one into a check. The pattern was clear: every gate that was a script caught things, and every gate that was prose in a skill file got skipped, including by me.

## `tools/check-course.py`

| Check | The mistake it exists for |
|---|---|
| Cross-lab handoffs | My week 7 rewrite stopped writing `trivy-k8s.json`, which lab 10's importer reads. Nothing noticed until I ran the importer by hand, six commits later. |
| Shipped files no lab mentions | lab 9's `compose-security.rego` had quietly become dead plumbing; lab 5 shipped a script whose paths came from a version of the lab that no longer existed. |
| Version disagreements | Three shipped in this branch: CycloneDX 1.6 vs 1.7, k3s 1.31 vs 1.33, Falco 0.43.0 vs 0.43.1. Found by an external review, not by me. |
| Structure, point totals, acceptance coverage | Labs 7 and 11 shipped with acceptance criteria covering about half of what their tasks required. |

Every check was regression-tested by reintroducing the original defect and confirming it gets reported.

The handoff check reads **shipped scripts as well as lab specs**, because in the case that actually broke, the script was the only consumer. Artifacts a later lab needs are now declared in the producing lab:

```
<!-- produces: labs/lab7/results/trivy-k8s.json for lab 10 -->
```

A declaration rather than a cleverer regex, deliberately. An earlier draft of this checker tried to recognise every way a tool can be told to write a file, and its `mkdir -p` heuristic is exactly what hid the dropped handoff in the first place. The declaration also does something a regex never could: it tells a reader the file matters later.

## Weekly workflow

Adds `check-course.py` and `shellcheck -S warning` over every shipped script. Shellcheck's first run found a real bug in `verify-lab.sh`: `printf ... "$?"` inside an `else` branch reports the status of the `if` condition rather than the block, so a failing lab printed the wrong exit code. Same class as the `$?`-after-a-pipeline bug Codex found in this very workflow.

## Two rules that cannot be automated

Added to the skills rather than the tools:

- **Rewriting a lab requires diffing its requirements.** List what the old version demanded, mark each item kept, changed or dropped, and name the dropped ones in the PR. Four requirements went missing that way on this course, and a review caught them, not me.
- **Any string a student types verbatim comes from tool output.** A predicate URI, a parser name, a rule id, an enum value. The two worst defects in the last PR were a Cosign predicate type and a DefectDojo parser name that were both entirely plausible and both wrong.

## For the other three courses

`tools/` plus `.github/` is now the thing to copy into DevOps-Intro, SRE-Intro and DevOps-Core. Copy it **first**, run `check-course.py`, and fix what it reports before writing anything new: on this repo it would have reported four real problems on day one.
