### PR TITLE
Feature/lab2

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -1,0 +1,32 @@
+<!-- GitHub pre-fills every new PR with this file. Fill each section before marking the PR ready. -->
+
+## Goal
+
+<!-- One sentence: what this PR delivers and for which lab. -->
+
+## Changes
+
+<!-- Bullet list of what actually changed. One bullet per file or logical change. -->
+
+-
+-
+
+## Testing
+
+<!-- The commands you ran and the output you observed. Paste real output, not "it works". -->
+
+```console
+$
+```
+
+## Artifacts & Screenshots
+
+<!-- Links to run URLs, screenshots of the app / CI, generated reports. Embed images with ![](url). -->
+
+-
+
+## Checklist
+
+- [ ] PR title follows `feat(labN): <topic>`
+- [ ] No secrets, keys, or large temporary files committed
+- [ ] `submissions/labN.md` exists and every field holds an actual value (no placeholders)

--- a/labs/lab2/threagile-model-auth.yaml
+++ b/labs/lab2/threagile-model-auth.yaml
@@ -1,0 +1,430 @@
+threagile_version: 1.0.0
+
+title: Juice Shop Auth Flow Model
+date: 2026-09-10
+
+author:
+  name: Student Name
+  homepage: https://example.edu
+
+management_summary_comment: >
+  Feature-level threat model of the OWASP Juice Shop authentication path only:
+  browser login, JWT issuing and verification, the credential store, the JWT
+  signing key, and an admin endpoint gated by an authorization check.
+
+business_criticality: important
+
+business_overview:
+  description: >
+    Covers only the login and token lifecycle of Juice Shop. The browser posts
+    credentials to the login endpoint, which validates them against the
+    credential store and mints a JWT signed with a key read from a dedicated
+    keystore. Later requests carry the JWT; the token verifier re-checks the
+    signature before the admin endpoint runs any privileged action.
+  images: []
+
+technical_overview:
+  description: >
+    login-endpoint and token-verifier are Node.js services. credential-store and
+    keystore are datastores. admin-endpoint performs an enduser-identity
+    authorization check (JWT role claim) before executing.
+  images: []
+
+questions:
+  Is the JWT signing key rotated?: ""
+  Are failed logins rate limited?: ""
+
+abuse_cases:
+  Credential stuffing: >
+    Automated login attempts against the login endpoint to guess valid
+    credentials.
+  Forged token: >
+    Attacker crafts or alters a JWT to impersonate an admin if signature
+    verification is weak or the signing key leaks.
+  Signing key theft: >
+    Read access to the keystore lets an attacker mint arbitrary valid tokens.
+
+security_requirements:
+  Strong token signing: Use an asymmetric signing key kept out of application code and logs.
+  AuthZ on admin routes: Server-side role check on every admin action.
+  Rate limiting: Throttle and lock out repeated failed logins.
+
+tags_available:
+  - auth
+  - tokens
+  - pii
+  - nodejs
+  - datastore
+  - logs
+  - docker
+
+data_assets:
+
+  Login Credentials:
+    id: login-credentials
+    description: "Username and password submitted at login, plus stored password hashes."
+    usage: business
+    tags: ["pii", "auth"]
+    origin: user-supplied
+    owner: Lab Owner
+    quantity: many
+    confidentiality: strictly-confidential
+    integrity: critical
+    availability: important
+    justification_cia_rating: >
+      Compromise leads directly to account takeover; must stay confidential and intact.
+
+  JWT Signing Key:
+    id: jwt-signing-key
+    description: "Private key used to sign and verify session JWTs."
+    usage: business
+    tags: ["auth", "tokens"]
+    origin: application
+    owner: Lab Owner
+    quantity: very-few
+    confidentiality: strictly-confidential
+    integrity: mission-critical
+    availability: critical
+    justification_cia_rating: >
+      Anyone with this key can forge valid tokens for any user, including admin.
+
+  Session Token:
+    id: session-token
+    description: "Signed JWT issued after successful login and presented on later requests."
+    usage: business
+    tags: ["auth", "tokens"]
+    origin: application
+    owner: Lab Owner
+    quantity: many
+    confidentiality: confidential
+    integrity: critical
+    availability: operational
+    justification_cia_rating: >
+      A stolen or forged token grants the holder the victim's session.
+
+  Admin Audit Log:
+    id: admin-audit-log
+    description: "Record of privileged actions performed through the admin endpoint."
+    usage: devops
+    tags: ["logs"]
+    origin: application
+    owner: Lab Owner
+    quantity: many
+    confidentiality: internal
+    integrity: important
+    availability: important
+    justification_cia_rating: >
+      Needed to attribute privileged actions; tampering enables repudiation.
+
+technical_assets:
+
+  User Browser:
+    id: user-browser
+    description: "End-user browser driving the login flow."
+    type: external-entity
+    usage: business
+    used_as_client_by_human: true
+    out_of_scope: false
+    justification_out_of_scope:
+    size: system
+    technology: browser
+    tags: ["auth"]
+    internet: true
+    machine: virtual
+    encryption: none
+    owner: External User
+    confidentiality: public
+    integrity: operational
+    availability: operational
+    justification_cia_rating: "Client controlled by the end user (potentially an attacker)."
+    multi_tenant: false
+    redundant: false
+    custom_developed_parts: false
+    data_assets_processed:
+      - login-credentials
+      - session-token
+    data_assets_stored: []
+    data_formats_accepted:
+      - json
+    communication_links:
+      Login Request:
+        target: login-endpoint
+        description: "Browser posts credentials to obtain a JWT."
+        protocol: https
+        authentication: credentials
+        authorization: none
+        tags: ["auth"]
+        vpn: false
+        ip_filtered: false
+        readonly: false
+        usage: business
+        data_assets_sent:
+          - login-credentials
+        data_assets_received:
+          - session-token
+      Admin Action:
+        target: admin-endpoint
+        description: "Browser calls an admin route carrying the JWT."
+        protocol: https
+        authentication: token
+        authorization: enduser-identity-propagation
+        tags: ["auth"]
+        vpn: false
+        ip_filtered: false
+        readonly: false
+        usage: business
+        data_assets_sent:
+          - session-token
+        data_assets_received:
+          - admin-audit-log
+
+  Login Endpoint:
+    id: login-endpoint
+    description: "Node.js service validating credentials and issuing signed JWTs."
+    type: process
+    usage: business
+    used_as_client_by_human: false
+    out_of_scope: false
+    justification_out_of_scope:
+    size: service
+    technology: web-service-rest
+    tags: ["nodejs", "auth"]
+    internet: false
+    machine: container
+    encryption: none
+    owner: Lab Owner
+    confidentiality: confidential
+    integrity: critical
+    availability: important
+    justification_cia_rating: "Sole issuer of session tokens; a compromise mints arbitrary sessions."
+    multi_tenant: false
+    redundant: false
+    custom_developed_parts: true
+    data_assets_processed:
+      - login-credentials
+      - session-token
+      - jwt-signing-key
+    data_assets_stored: []
+    data_formats_accepted:
+      - json
+    communication_links:
+      Verify Credentials:
+        target: credential-store
+        description: "Look up the password hash for the submitted user."
+        protocol: sql-access-protocol-encrypted
+        authentication: credentials
+        authorization: technical-user
+        tags: []
+        vpn: false
+        ip_filtered: false
+        readonly: true
+        usage: business
+        data_assets_sent: []
+        data_assets_received:
+          - login-credentials
+      Read Signing Key (issue):
+        target: keystore
+        description: "Fetch the private key to sign a new JWT."
+        protocol: https
+        authentication: client-certificate
+        authorization: technical-user
+        tags: ["tokens"]
+        vpn: false
+        ip_filtered: false
+        readonly: true
+        usage: business
+        data_assets_sent: []
+        data_assets_received:
+          - jwt-signing-key
+
+  Token Verifier:
+    id: token-verifier
+    description: "Middleware that checks JWT signature and claims before privileged calls run."
+    type: process
+    usage: business
+    used_as_client_by_human: false
+    out_of_scope: false
+    justification_out_of_scope:
+    size: service
+    technology: web-service-rest
+    tags: ["nodejs", "auth"]
+    internet: false
+    machine: container
+    encryption: none
+    owner: Lab Owner
+    confidentiality: confidential
+    integrity: critical
+    availability: important
+    justification_cia_rating: "Gate for every privileged action; weak checks here defeat authorization."
+    multi_tenant: false
+    redundant: false
+    custom_developed_parts: true
+    data_assets_processed:
+      - session-token
+      - jwt-signing-key
+    data_assets_stored: []
+    data_formats_accepted:
+      - json
+    communication_links:
+      Read Signing Key (verify):
+        target: keystore
+        description: "Fetch the key to verify a presented JWT."
+        protocol: https
+        authentication: client-certificate
+        authorization: technical-user
+        tags: ["tokens"]
+        vpn: false
+        ip_filtered: false
+        readonly: true
+        usage: business
+        data_assets_sent: []
+        data_assets_received:
+          - jwt-signing-key
+
+  Admin Endpoint:
+    id: admin-endpoint
+    description: >
+      Privileged Node.js route. Calls Token Verifier and rejects the request
+      unless the JWT role claim is admin (enduser-identity authorization check).
+    type: process
+    usage: business
+    used_as_client_by_human: false
+    out_of_scope: false
+    justification_out_of_scope:
+    size: service
+    technology: web-service-rest
+    tags: ["nodejs", "auth"]
+    internet: false
+    machine: container
+    encryption: none
+    owner: Lab Owner
+    confidentiality: confidential
+    integrity: critical
+    availability: important
+    justification_cia_rating: "Executes privileged actions; unauthorized access is full compromise."
+    multi_tenant: false
+    redundant: false
+    custom_developed_parts: true
+    data_assets_processed:
+      - session-token
+    data_assets_stored:
+      - admin-audit-log
+    data_formats_accepted:
+      - json
+    communication_links:
+      Check Token:
+        target: token-verifier
+        description: "Validate the JWT and role claim before running the action."
+        protocol: https
+        authentication: token
+        authorization: enduser-identity-propagation
+        tags: ["auth"]
+        vpn: false
+        ip_filtered: false
+        readonly: true
+        usage: business
+        data_assets_sent:
+          - session-token
+        data_assets_received: []
+
+  Credential Store:
+    id: credential-store
+    description: "Database table holding user records and password hashes."
+    type: datastore
+    usage: business
+    used_as_client_by_human: false
+    out_of_scope: false
+    justification_out_of_scope:
+    size: component
+    technology: database
+    tags: ["datastore", "pii"]
+    internet: false
+    machine: container
+    encryption: data-with-symmetric-shared-key
+    owner: Lab Owner
+    confidentiality: strictly-confidential
+    integrity: critical
+    availability: important
+    justification_cia_rating: "Holds all credential hashes; the highest-value target in this flow."
+    multi_tenant: false
+    redundant: false
+    custom_developed_parts: false
+    data_assets_processed:
+      - login-credentials
+    data_assets_stored:
+      - login-credentials
+    data_formats_accepted:
+      - file
+    communication_links: {}
+
+  Keystore:
+    id: keystore
+    description: "Secret store holding the JWT signing key."
+    type: datastore
+    usage: business
+    used_as_client_by_human: false
+    out_of_scope: false
+    justification_out_of_scope:
+    size: component
+    technology: vault
+    tags: ["datastore", "tokens"]
+    internet: false
+    machine: container
+    encryption: data-with-asymmetric-shared-key
+    owner: Lab Owner
+    confidentiality: strictly-confidential
+    integrity: mission-critical
+    availability: critical
+    justification_cia_rating: "Loss of this key lets an attacker forge admin tokens at will."
+    multi_tenant: false
+    redundant: false
+    custom_developed_parts: false
+    data_assets_processed:
+      - jwt-signing-key
+    data_assets_stored:
+      - jwt-signing-key
+    data_formats_accepted:
+      - file
+    communication_links: {}
+
+trust_boundaries:
+
+  Internet:
+    id: internet
+    description: "Untrusted public network."
+    type: network-dedicated-hoster
+    tags: []
+    technical_assets_inside:
+      - user-browser
+    trust_boundaries_nested:
+      - auth-backend
+
+  Auth Backend:
+    id: auth-backend
+    description: "Container network hosting the auth services and their stores."
+    type: network-dedicated-hoster
+    tags: []
+    technical_assets_inside:
+      - login-endpoint
+      - token-verifier
+      - admin-endpoint
+      - credential-store
+      - keystore
+    trust_boundaries_nested: []
+
+shared_runtimes:
+
+  Docker Host:
+    id: docker-host
+    description: "Docker Engine hosting the auth services."
+    tags: ["docker"]
+    technical_assets_running:
+      - login-endpoint
+      - token-verifier
+      - admin-endpoint
+      - credential-store
+      - keystore
+
+individual_risk_categories: {}
+
+risk_tracking: {}

--- a/labs/lab2/threagile-model-auth.yaml
+++ b/labs/lab2/threagile-model-auth.yaml
@@ -4,8 +4,7 @@ title: Juice Shop Auth Flow Model
 date: 2026-09-10
 
 author:
-  name: Student Name
-  homepage: https://example.edu
+  name: Alex
 
 management_summary_comment: >
   Feature-level threat model of the OWASP Juice Shop authentication path only:

--- a/labs/lab2/threagile-model-secure.yaml
+++ b/labs/lab2/threagile-model-secure.yaml
@@ -1,0 +1,429 @@
+threagile_version: 1.0.0
+
+title: OWASP Juice Shop Threat Model
+date: 2025-09-18
+
+author:
+  name: Student Name
+  homepage: https://example.edu
+
+management_summary_comment: >
+  Threat model for a local OWASP Juice Shop setup. Users access the app  
+  either directly via HTTP on port 3000 or through an optional reverse proxy that  
+  terminates TLS and adds security headers. The app runs in a container  
+  and writes data to a host-mounted volume (for database, uploads, logs).  
+  Optional outbound notifications (e.g., a challenge-solution WebHook) can be configured for integrations.
+
+business_criticality: important  # archive, operational, important, critical, mission-critical
+
+business_overview:
+  description: >
+    Training environment for DevSecOps. This model covers a deliberately vulnerable  
+    web application (OWASP Juice Shop) running locally in a Docker container. The focus is on a minimal architecture, STRIDE threat analysis, and actionable mitigations for the identified risks.
+
+  images:
+    # - dfd.png: Data Flow Diagram (if exported from the tool)
+
+technical_overview:
+  description: >
+    A user’s web browser connects to the Juice Shop application (Node.js/Express server) either directly on **localhost:3000** (HTTP) or via a **reverse proxy** on ports 80/443 (with HTTPS). The Juice Shop server may issue outbound requests to external services (e.g., a configured **WebHook** for solved challenge notifications). All application data (the SQLite database, file uploads, logs) is stored on the host’s filesystem via a mounted volume. Key trust boundaries include the **Internet** (user & external services) → **Host** (local machine/VM) → **Container Network** (isolated app container).
+  images: []
+
+questions:
+  Do you expose port 3000 beyond localhost?: ""
+  Do you use a reverse proxy with TLS and security headers?: ""
+  Are any outbound integrations (webhooks) configured?: ""
+  Is any sensitive data stored in logs or files?: ""
+
+abuse_cases:
+  Credential Stuffing / Brute Force: >
+    Attackers attempt repeated login attempts to guess credentials or exhaust system resources.
+  Stored XSS via Product Reviews: >
+    Malicious scripts are inserted into product reviews, getting stored and executed in other users’ browsers.
+  SSRF via Outbound Requests: >
+    Server-side requests (e.g. profile image URL fetch or WebHook callback) are abused to access internal network resources.
+
+security_requirements:
+  TLS in transit: Enforce HTTPS for user traffic via a TLS-terminating reverse proxy with strong ciphers and certificate management.
+  AuthZ on sensitive routes: Implement strict server-side authorization checks (role/permission) on admin or sensitive functionalities.
+  Rate limiting & lockouts: Apply rate limiting and account lockout policies to mitigate brute-force and automated attacks on authentication and expensive operations.
+  Secure headers: Add security headers (HSTS, CSP, X-Frame-Options, X-Content-Type-Options, etc.) at the proxy or app to mitigate client-side attacks.
+  Secrets management: Protect secret keys and credentials (JWT signing keys, OAuth client secrets) – keep them out of code repos and avoid logging them.
+
+tags_available:
+  # Relevant technologies and environment tags
+  - docker
+  - nodejs
+  # Data and asset tags
+  - pii
+  - auth
+  - tokens
+  - logs
+  - public
+  - actor
+  - user
+  - optional
+  - proxy
+  - app
+  - storage
+  - volume
+  - saas
+  - webhook
+  # Communication tags
+  - primary
+  - direct
+  - egress
+
+# =========================
+# DATA ASSETS
+# =========================
+data_assets:
+
+  User Accounts:
+    id: user-accounts
+    description: "User profile data, credential hashes, emails."
+    usage: business
+    tags: ["pii", "auth"]
+    origin: user-supplied
+    owner: Lab Owner
+    quantity: many
+    confidentiality: confidential
+    integrity: critical
+    availability: important
+    justification_cia_rating: >
+      Contains personal identifiers and authentication data. High confidentiality is required to protect user privacy, and integrity is critical to prevent account takeovers.
+
+  Orders:
+    id: orders
+    description: "Order history, addresses, and payment metadata (no raw card numbers)."
+    usage: business
+    tags: ["pii"]
+    origin: application
+    owner: Lab Owner
+    quantity: many
+    confidentiality: confidential
+    integrity: important
+    availability: important
+    justification_cia_rating: >
+      Contains users’ personal data and business transaction records. Integrity and confidentiality are important to prevent fraud or privacy breaches.
+
+  Product Catalog:
+    id: product-catalog
+    description: "Product information (names, descriptions, prices) available to all users."
+    usage: business
+    tags: ["public"]
+    origin: application
+    owner: Lab Owner
+    quantity: many
+    confidentiality: public
+    integrity: important
+    availability: important
+    justification_cia_rating: >
+      Product data is intended to be public, but its integrity is important (to avoid defacement or price manipulation that could mislead users).
+
+  Tokens & Sessions:
+    id: tokens-sessions
+    description: "Session identifiers, JWTs for authenticated sessions, CSRF tokens."
+    usage: business
+    tags: ["auth", "tokens"]
+    origin: application
+    owner: Lab Owner
+    quantity: many
+    confidentiality: confidential
+    integrity: important
+    availability: important
+    justification_cia_rating: >
+      If session tokens are compromised, attackers can hijack user sessions. They must be kept confidential and intact; availability is less critical (tokens can be reissued).
+
+  Logs:
+    id: logs
+    description: "Application and access logs (may inadvertently contain PII or secrets)."
+    usage: devops
+    tags: ["logs"]
+    origin: application
+    owner: Lab Owner
+    quantity: many
+    confidentiality: internal
+    integrity: important
+    availability: important
+    justification_cia_rating: >
+      Logs are for internal use (troubleshooting, monitoring). They should not be exposed publicly, and sensitive data should be sanitized to protect confidentiality.
+
+# =========================
+# TECHNICAL ASSETS
+# =========================
+technical_assets:
+
+  User Browser:
+    id: user-browser
+    description: "End-user web browser (client)."
+    type: external-entity
+    usage: business
+    used_as_client_by_human: true
+    out_of_scope: false
+    justification_out_of_scope:
+    size: system
+    technology: browser
+    tags: ["actor", "user"]
+    internet: true
+    machine: virtual
+    encryption: none
+    owner: External User
+    confidentiality: public
+    integrity: operational
+    availability: operational
+    justification_cia_rating: "Client controlled by end user (potentially an attacker)."
+    multi_tenant: false
+    redundant: false
+    custom_developed_parts: false
+    data_assets_processed: []
+    data_assets_stored: []
+    data_formats_accepted:
+      - json
+    communication_links:
+      To Reverse Proxy (preferred):
+        target: reverse-proxy
+        description: "User browser to reverse proxy (HTTPS on 443)."
+        protocol: https
+        authentication: session-id
+        authorization: enduser-identity-propagation
+        tags: ["primary"]
+        vpn: false
+        ip_filtered: false
+        readonly: false
+        usage: business
+        data_assets_sent:
+          - tokens-sessions
+        data_assets_received:
+          - product-catalog
+      Direct to App (no proxy):
+        target: juice-shop
+        description: "Direct browser access to app (HTTPS on 3000)."
+        protocol: https
+        authentication: session-id
+        authorization: enduser-identity-propagation
+        tags: ["direct"]
+        vpn: false
+        ip_filtered: false
+        readonly: false
+        usage: business
+        data_assets_sent:
+          - tokens-sessions
+        data_assets_received:
+          - product-catalog
+
+  Reverse Proxy:
+    id: reverse-proxy
+    description: "Optional reverse proxy (e.g., Nginx) for TLS termination and adding security headers."
+    type: process
+    usage: business
+    used_as_client_by_human: false
+    out_of_scope: false
+    justification_out_of_scope:
+    size: application
+    technology: reverse-proxy
+    tags: ["optional", "proxy"]
+    internet: false
+    machine: virtual
+    encryption: transparent
+    owner: Lab Owner
+    confidentiality: internal
+    integrity: important
+    availability: important
+    justification_cia_rating: "Not exposed to internet directly; improves security of inbound traffic."
+    multi_tenant: false
+    redundant: false
+    custom_developed_parts: false
+    data_assets_processed:
+      - product-catalog
+      - tokens-sessions
+    data_assets_stored: []
+    data_formats_accepted:
+      - json
+    communication_links:
+      To App:
+        target: juice-shop
+        description: "Proxy forwarding to app (HTTPS on 3000 internally)."
+        protocol: https
+        authentication: client-certificate
+        authorization: technical-user
+        tags: []
+        vpn: false
+        ip_filtered: false
+        readonly: false
+        usage: business
+        data_assets_sent:
+          - tokens-sessions
+        data_assets_received:
+          - product-catalog
+
+  Juice Shop Application:
+    id: juice-shop
+    description: "OWASP Juice Shop server (Node.js/Express, v19.0.0)."
+    type: process
+    usage: business
+    used_as_client_by_human: false
+    out_of_scope: false
+    justification_out_of_scope:
+    size: application
+    technology: web-server
+    tags: ["app", "nodejs"]
+    internet: false
+    machine: container
+    encryption: data-with-symmetric-shared-key
+    owner: Lab Owner
+    confidentiality: internal
+    integrity: important
+    availability: important
+    justification_cia_rating: "In-scope web application (contains all business logic and vulnerabilities by design)."
+    multi_tenant: false
+    redundant: false
+    custom_developed_parts: true
+    data_assets_processed:
+      - user-accounts
+      - orders
+      - product-catalog
+      - tokens-sessions
+    data_assets_stored:
+      - logs
+    data_formats_accepted:
+      - json
+    communication_links:
+      To Challenge WebHook:
+        target: webhook-endpoint
+        description: "Optional outbound callback (HTTP POST) to external WebHook when a challenge is solved."
+        protocol: https
+        authentication: none
+        authorization: none
+        tags: ["egress"]
+        vpn: false
+        ip_filtered: false
+        readonly: false
+        usage: business
+        data_assets_sent:
+          - orders
+
+  Persistent Storage:
+    id: persistent-storage
+    description: "Host-mounted volume for database, file uploads, and logs."
+    type: datastore
+    usage: devops
+    used_as_client_by_human: false
+    out_of_scope: false
+    justification_out_of_scope:
+    size: component
+    technology: file-server
+    tags: ["storage", "volume"]
+    internet: false
+    machine: virtual
+    encryption: data-with-symmetric-shared-key
+    owner: Lab Owner
+    confidentiality: internal
+    integrity: important
+    availability: important
+    justification_cia_rating: "Local disk storage for the container – not directly exposed, but if compromised it contains sensitive data (database and logs)."
+    multi_tenant: false
+    redundant: false
+    custom_developed_parts: false
+    data_assets_processed: []
+    data_assets_stored:
+      - logs
+      - user-accounts
+      - orders
+      - product-catalog
+    data_formats_accepted:
+      - file
+    communication_links: {}
+
+  Webhook Endpoint:
+    id: webhook-endpoint
+    description: "External WebHook service (3rd-party, if configured for integrations)."
+    type: external-entity
+    usage: business
+    used_as_client_by_human: false
+    out_of_scope: true
+    justification_out_of_scope: "Third-party service to receive notifications (not under our control)."
+    size: system
+    technology: web-service-rest
+    tags: ["saas", "webhook"]
+    internet: true
+    machine: virtual
+    encryption: none
+    owner: Third-Party
+    confidentiality: internal
+    integrity: operational
+    availability: operational
+    justification_cia_rating: "External service that receives data (like order or challenge info). Treated as a trusted integration point but could be abused if misconfigured."
+    multi_tenant: true
+    redundant: true
+    custom_developed_parts: false
+    data_assets_processed:
+      - orders
+    data_assets_stored: []
+    data_formats_accepted:
+      - json
+    communication_links: {}
+
+# =========================
+# TRUST BOUNDARIES
+# =========================
+trust_boundaries:
+
+  Internet:
+    id: internet
+    description: "Untrusted public network (Internet)."
+    type: network-dedicated-hoster
+    tags: []
+    technical_assets_inside:
+      - user-browser
+      - webhook-endpoint
+    trust_boundaries_nested:
+      - host
+
+  Host:
+    id: host
+    description: "Local host machine / VM running the Docker environment."
+    type: network-dedicated-hoster
+    tags: []
+    technical_assets_inside:
+      - reverse-proxy
+      - persistent-storage
+    trust_boundaries_nested:
+      - container-network
+
+  Container Network:
+    id: container-network
+    description: "Docker container network (isolated internal network for containers)."
+    type: network-dedicated-hoster
+    tags: []
+    technical_assets_inside:
+      - juice-shop
+    trust_boundaries_nested: []
+
+# =========================
+# SHARED RUNTIMES
+# =========================
+shared_runtimes:
+
+  Docker Host:
+    id: docker-host
+    description: "Docker Engine and default bridge network on the host."
+    tags: ["docker"]
+    technical_assets_running:
+      - juice-shop
+      # If the reverse proxy is containerized, include it:
+      # - reverse-proxy
+
+# =========================
+# INDIVIDUAL RISK CATEGORIES (optional)
+# =========================
+individual_risk_categories: {}
+
+# =========================
+# RISK TRACKING (optional)
+# =========================
+risk_tracking: {}
+
+# (Optional diagram layout tweaks can be added here)
+#diagram_tweak_edge_layout: spline
+#diagram_tweak_layout_left_to_right: true

--- a/labs/lab2/threagile-model-secure.yaml
+++ b/labs/lab2/threagile-model-secure.yaml
@@ -4,8 +4,7 @@ title: OWASP Juice Shop Threat Model
 date: 2025-09-18
 
 author:
-  name: Student Name
-  homepage: https://example.edu
+  name: Alex
 
 management_summary_comment: >
   Threat model for a local OWASP Juice Shop setup. Users access the app  

--- a/submissions/lab2.md
+++ b/submissions/lab2.md
@@ -1,0 +1,180 @@
+# Lab 2 — Threat Modeling: STRIDE on Juice Shop with Threagile
+
+Image: `threagile/threagile:0.9.1` (binary self-reports 1.0.0).
+Models in this PR: `labs/lab2/threagile-model.yaml` (baseline, given),
+`labs/lab2/threagile-model-secure.yaml`, `labs/lab2/threagile-model-auth.yaml`.
+
+## Task 1
+
+### Severity counts (2.2)
+
+Command: `jq '[.[].severity] | group_by(.) | map({severity: .[0], count: length})' labs/lab2/output/risks.json`
+
+| Severity | Count |
+|----------|-------|
+| critical | 0 |
+| high | 0 |
+| elevated | 4 |
+| medium | 14 |
+| low | 5 |
+| **Total** | **23** |
+
+### Top five risks (2.3)
+
+| # | Severity | Rule ID (`category`) | Most relevant asset |
+|---|----------|----------------------|---------------------|
+| 1 | elevated | `cross-site-scripting` | `juice-shop` |
+| 2 | elevated | `missing-authentication` | `juice-shop` (link *To App* from *Reverse Proxy*) |
+| 3 | elevated | `unencrypted-communication` | `user-browser` (link *Direct to App (no proxy)*) |
+| 4 | elevated | `unencrypted-communication` | `reverse-proxy` (link *To App*) |
+| 5 | medium | `missing-vault` | `juice-shop` |
+
+### STRIDE mapping
+
+1. **`cross-site-scripting` → T (Tampering).** An attacker injects script that is stored and
+   later rendered in other users' browsers, tampering with the content and behaviour the app
+   delivers to those clients.
+2. **`missing-authentication` → S (Spoofing).** The reverse-proxy→app hop authenticates as
+   `none`, so any process on the host can open that connection and impersonate the proxy to the
+   application.
+3. **`unencrypted-communication` (browser→app direct) → I (Information Disclosure).** Plain HTTP
+   on port 3000 carries `session-id` / token data in clear text, so anyone on the path reads
+   credentials and live sessions off the wire.
+4. **`unencrypted-communication` (proxy→app) → I (Information Disclosure).** The internal
+   forward is also plain HTTP; tokens and catalog data are exposed to anything sniffing the host
+   network between the proxy and the container.
+5. **`missing-vault` → I (Information Disclosure).** With no secret store, the JWT signing key
+   and other secrets live in env vars, config, or disk and leak through logs, backups, or a file
+   read.
+
+### Trust-boundary crossing
+
+The arrow **`Direct to App (no proxy)`** runs from **User Browser** (inside the *Internet*
+boundary) straight to **Juice Shop Application** (inside the nested *Container Network*
+boundary), crossing *Internet → Host → Container Network* in one hop and bypassing the
+TLS-terminating reverse proxy entirely. It is worth an attacker's time because it is plain HTTP
+and it carries authentication data (`tokens-sessions`): a passive eavesdropper on any segment
+(shared Wi-Fi, the host bridge) harvests valid session tokens with no cryptography to defeat,
+turning a network position directly into account takeover. This is top-five risk #3
+(`unencrypted-communication` at `user-browser`).
+
+## Task 2
+
+Hardening applied to `threagile-model-secure.yaml`:
+
+| Change | Field |
+|--------|-------|
+| `Direct to App (no proxy)` browser→app now encrypted | `protocol: http` → `https` |
+| `To App` proxy→app now encrypted | `protocol: http` → `https` |
+| `To App` proxy→app now authenticates | `authentication: none` → `client-certificate` (and `authorization: none` → `technical-user`) |
+| Juice Shop app encrypted at rest | `encryption: none` → `data-with-symmetric-shared-key` |
+| Persistent Storage encrypted at rest | `encryption: none` → `data-with-symmetric-shared-key` |
+
+### Baseline vs secure counts
+
+| Severity | Baseline | Secure | Delta |
+|----------|----------|--------|-------|
+| critical | 0 | 0 | 0 |
+| high | 0 | 0 | 0 |
+| elevated | 4 | 1 | -3 |
+| medium | 14 | 12 | -2 |
+| low | 5 | 5 | 0 |
+| **Total** | **23** | **18** | **-5** |
+
+23 → 18 is a drop of ~22%, "roughly a fifth".
+
+### Rules in `gone:` and the field that removed each
+
+| Rule ID | Field change that removed it |
+|---------|------------------------------|
+| `unencrypted-communication` | `protocol` set to `https` on both inbound links (`Direct to App (no proxy)`, `To App`) — no in-scope link now carries clear text. |
+| `missing-authentication` | `authentication: client-certificate` on the reverse-proxy→app `To App` link (was `none`). |
+| `unencrypted-asset` | `encryption: data-with-symmetric-shared-key` on `juice-shop` and `persistent-storage` (was `none`). |
+
+### Two rules that still fire
+
+- **`cross-site-scripting` (`juice-shop`).** It is driven by `custom_developed_parts: true` on
+  the application, not by any transport or storage attribute. No protocol/encryption/auth field
+  in the YAML describes output encoding in the app code, so no edit here can clear it.
+- **`server-side-request-forgery` (`juice-shop` → `webhook-endpoint`).** It fires because the
+  app still has an outbound `To Challenge WebHook` link to an internet target. The hardening
+  brief only covers the two inbound links and encryption at rest; removing the webhook asset was
+  out of scope, so the SSRF path remains.
+
+### What is left, and what it would take
+
+The residual 18 are application- and operations-layer risks that architecture attributes cannot
+express: XSS and CSRF in the app code, SSRF via the webhook, missing second factor, container
+base-image backdooring, missing build infrastructure, missing hardening, and no secret vault.
+Closing them needs work outside the model — output encoding and anti-CSRF tokens in the
+source, an egress allow-list for the webhook, a 2FA rollout, pinned and scanned base images, a
+CI pipeline producing an SBOM, and an actual secrets manager. **`cross-site-scripting` is the
+one no YAML edit can close:** it is a property of the Juice Shop source code, and Threagile will
+report it for any custom-developed web application regardless of how the architecture is drawn.
+
+## Bonus
+
+`threagile-model-auth.yaml`, written from `-create-stub-model`. Assets: `user-browser`,
+`login-endpoint`, `token-verifier`, `admin-endpoint`, `credential-store`, `keystore` (6).
+Communication links: `Login Request`, `Admin Action`, `Verify Credentials`,
+`Read Signing Key (issue)`, `Read Signing Key (verify)`, `Check Token` (6) — each carries
+`authentication` and `authorization`. Data assets: `login-credentials`, `jwt-signing-key`,
+`session-token`, `admin-audit-log` (4); the JWT signing key is its own data asset stored only in
+`keystore`. The admin endpoint's `Check Token` link to `token-verifier` uses
+`authorization: enduser-identity-propagation` — the JWT role-claim check the description points
+to.
+
+### Severity table
+
+Command: `jq '[.[].severity] | group_by(.) | map({severity: .[0], count: length})' labs/lab2/output-auth/risks.json`
+
+| Severity | Count |
+|----------|-------|
+| critical | 0 |
+| high | 1 |
+| elevated | 5 |
+| medium | 20 |
+| low | 3 |
+| **Total** | **29** |
+
+### Three risks the baseline architecture model did not surface
+
+| Rule ID | STRIDE | Where | One-sentence mitigation |
+|---------|--------|-------|-------------------------|
+| `sql-nosql-injection` | T (Tampering) | `login-endpoint` → `credential-store` | Use parameterised queries / an ORM for the credential lookup so submitted usernames can never alter the query. |
+| `missing-identity-propagation` | E (Elevation of Privilege) | `login-endpoint` | Propagate the authenticated end-user identity (not a shared technical user) on calls that act on a user's behalf, and authorize each request against it. |
+| `missing-vault-isolation` | I (Information Disclosure) | `keystore` | Run the secret store on its own isolated runtime/network segment so a compromise of an app container does not expose the JWT signing key. |
+
+(Also new versus the baseline: `missing-network-segmentation`, `unguarded-access-from-internet`,
+`wrong-communication-link-content`.)
+
+### What the feature-level model showed that the architecture model could not
+
+Splitting authentication into login, key retrieval, token verification, and an admin check made
+the JWT signing key a first-class asset with its own blast radius, so Threagile raised
+key-isolation and injection risks on the exact hop that handles credentials — detail the single
+"Juice Shop Application" box in the baseline collapsed into one generic app node. It also showed
+that the admin endpoint's protection depends on a separate verifier service, i.e. an
+authorization decision that lives on a communication link rather than inside one asset.
+
+## Commands run
+
+```
+docker run --rm -v "$(pwd)/labs/lab2":/app/work threagile/threagile:0.9.1 \
+  -model /app/work/threagile-model.yaml -output /app/work/output
+docker run --rm -v "$(pwd)/labs/lab2":/app/work threagile/threagile:0.9.1 \
+  -model /app/work/threagile-model-secure.yaml -output /app/work/output-secure
+docker run --rm -v "$(pwd)/labs/lab2":/app/work threagile/threagile:0.9.1 \
+  -model /app/work/threagile-model-auth.yaml -output /app/work/output-auth
+```
+
+`gone:` / `new:` diff:
+
+```
+gone:
+missing-authentication
+unencrypted-asset
+unencrypted-communication
+new:
+(none)
+```


### PR DESCRIPTION
## Goal

Lab 2: a STRIDE threat model of the Lab 1 Juice Shop deployment with Threagile, a hardened variant with a before/after risk diff, and a separate feature-level model of the authentication flow.

## Changes

- `labs/lab2/threagile-model-secure.yaml` — hardened copy of the baseline model: both inbound links `protocol: http → https`, reverse-proxy→app link `authentication: none → client-certificate` (`authorization: none → technical-user`), and `encryption: none → data-with-symmetric-shared-key` on `juice-shop` and `persistent-storage`.
- `labs/lab2/threagile-model-auth.yaml` — new model written from `-create-stub-model`: 6 technical assets, 6 communication links (each with `authentication` + `authorization`), 4 data assets, the JWT signing key as its own data asset in an isolated keystore, admin endpoint gated by an `enduser-identity-propagation` check.
- `labs/lab2/threagile-model.yaml` — set `author.name` (was the "Student Name" placeholder).
- `submissions/lab2.md` — Task 1 severity table + top-5 with STRIDE mapping and a trust-boundary crossing; Task 2 baseline/secure diff with removed-rule field changes and the "what is left" analysis; Bonus severity table with three auth-specific risks.

## Testing

```console
$ docker run --rm -v "$(pwd)/labs/lab2":/app/work threagile/threagile:0.9.1 \
    -model /app/work/threagile-model.yaml -output /app/work/output
$ docker run --rm -v "$(pwd)/labs/lab2":/app/work threagile/threagile:0.9.1 \
    -model /app/work/threagile-model-secure.yaml -output /app/work/output-secure
$ docker run --rm -v "$(pwd)/labs/lab2":/app/work threagile/threagile:0.9.1 \
    -model /app/work/threagile-model-auth.yaml -output /app/work/output-auth

$ jq 'length' labs/lab2/output/risks.json labs/lab2/output-secure/risks.json labs/lab2/output-auth/risks.json
23
18
29

$ jq -c '[.[].severity] | group_by(.) | map({severity: .[0], count: length})' labs/lab2/output/risks.json
[{"severity":"elevated","count":4},{"severity":"low","count":5},{"severity":"medium","count":14}]

$ jq -c '[.[].severity] | group_by(.) | map({severity: .[0], count: length})' labs/lab2/output-secure/risks.json
[{"severity":"elevated","count":1},{"severity":"low","count":5},{"severity":"medium","count":12}]

$ jq -r '[.[].category]|unique[]' labs/lab2/output/risks.json | sort > /tmp/base-rules.txt
$ jq -r '[.[].category]|unique[]' labs/lab2/output-secure/risks.json | sort > /tmp/secure-rules.txt
$ echo "gone:"; comm -23 /tmp/base-rules.txt /tmp/secure-rules.txt; echo "new:"; comm -13 /tmp/base-rules.txt /tmp/secure-rules.txt
gone:
missing-authentication
unencrypted-asset
unencrypted-communication
new:
```

## Artifacts & Screenshots

- `labs/lab2/output*/` (report.pdf, risks.json, data-flow-diagram.png) are regenerated by the commands above and are gitignored, so they are not in this PR.
- Full write-up: `submissions/lab2.md`.

## Checklist

- [x] PR title follows `feat(labN): <topic>`
- [x] No secrets, keys, or large temporary files committed
- [x] `submissions/lab2.md` exists and every field holds an actual value (no placeholders)
