### PR TITLE
feat(lab2): threat model, secure variant, auth flow

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -1,0 +1,31 @@
+## Goal
+
+<!-- One sentence: what this PR delivers and why. -->
+
+## Changes
+
+<!-- Bullet list of what was added or changed. -->
+
+-
+
+## Testing
+
+<!-- Commands you ran and the output you observed. -->
+
+```bash
+# command
+```
+
+```text
+# observed output
+```
+
+## Artifacts & Screenshots
+
+<!-- Links to reports, CI runs, SBOMs, scan results, or screenshots. -->
+
+## Checklist
+
+- [ ] PR title follows `feat(labN): <topic>`
+- [ ] No secrets or large temporary files committed
+- [ ] `submissions/labN.md` exists

--- a/labs/lab2/threagile-model-auth.yaml
+++ b/labs/lab2/threagile-model-auth.yaml
@@ -1,0 +1,472 @@
+threagile_version: 1.0.0
+
+# Feature-level model of the Juice Shop login path, written from the
+# -create-stub-model skeleton (not from the baseline architecture model).
+
+title: Juice Shop Auth Flow
+
+date: 2026-09-11
+
+author:
+  name: mobgun
+  homepage: https://github.com/mobgun
+
+management_summary_comment: >
+  Feature-level threat model of the OWASP Juice Shop v20.0.0 login path only:
+  the browser, the login endpoint, JWT issuing, JWT verification in front of the
+  admin endpoint, the credential store and the admin endpoint itself.
+
+business_criticality: important # values: archive, operational, important, critical, mission-critical
+
+business_overview:
+  description: >
+    Customers and administrators sign in with email and password. A successful
+    login returns a signed JWT that the single-page app sends with every later
+    API call, including calls to the administration API.
+  images:
+
+technical_overview:
+  description: >
+    POST /rest/user/login builds a raw SQL query on the SQLite Users table by
+    string interpolation. lib/insecurity then signs an RS256 JWT with a private
+    key that is hard-coded in the application code. On protected routes
+    security.isAuthorized() (express-jwt with encryptionkeys/jwt.pub) verifies
+    that signature. For GET /api/Users that is the whole check: any valid token
+    passes, whatever its role claim. PUT and DELETE on /api/Users/:id are denied
+    for everyone.
+  images:
+
+questions: # simply use "" as answer to signal "unanswered"
+  Where does the JWT signing key live, and who can read it?: ""
+  Is there rate limiting or account lockout on the login endpoint?: ""
+  Is the admin role check enforced server-side on every admin route?: ""
+
+abuse_cases:
+  SQL injection on login: >
+    The attacker sends a crafted email value so that the credential query
+    matches the admin row without knowing the password.
+  Token forgery: >
+    With the signing key, or a verifier that accepts weak algorithms, the
+    attacker mints a JWT with role admin and calls the admin API.
+  Credential stuffing: >
+    Leaked email and password pairs are replayed against the login endpoint.
+  Customer reads the user list: >
+    Any logged-in customer calls GET /api/Users directly, because the server
+    checks only that the token is valid, not that its role is admin.
+
+security_requirements:
+  Parameterized credential lookup: The login query uses bound parameters, never string concatenation.
+  Key outside the code: The JWT signing key comes from a secret store and can be rotated.
+  Server-side role check: Every admin route verifies the JWT signature and requires role admin.
+
+tags_available:
+  - nodejs
+  - express
+  - sqlite
+  - jwt
+  - admin
+  - authz-check
+
+
+data_assets:
+
+  User Credentials:
+    id: user-credentials
+    description: Email, password hash (unsalted MD5 in Juice Shop) and security-question answers.
+    usage: business # values: business, devops
+    tags:
+      - sqlite
+    origin: user-supplied
+    owner: Lab Owner
+    quantity: many # values: very-few, few, many, very-many
+    confidentiality: confidential # values: public, internal, restricted, confidential, strictly-confidential
+    integrity: critical # values: archive, operational, important, critical, mission-critical
+    availability: important # values: archive, operational, important, critical, mission-critical
+    justification_cia_rating: >
+      Leaked hashes can be cracked offline, and a changed row lets an attacker
+      take over any account.
+
+  JWT Signing Key:
+    id: jwt-signing-key
+    description: RSA private key that lib/insecurity uses to sign session JWTs.
+    usage: devops
+    tags:
+      - jwt
+    origin: application
+    owner: Lab Owner
+    quantity: very-few
+    confidentiality: strictly-confidential
+    integrity: critical
+    availability: important
+    justification_cia_rating: >
+      Whoever holds the key can mint a valid token for any user, including an admin.
+
+  Session Token:
+    id: session-token
+    description: Signed JWT with user id, email and role claim, kept in localStorage and a cookie.
+    usage: business
+    tags:
+      - jwt
+    origin: application
+    owner: Lab Owner
+    quantity: many
+    confidentiality: confidential
+    integrity: critical
+    availability: operational
+    justification_cia_rating: >
+      A stolen token is a live session, and a tampered role claim is privilege escalation.
+
+  Admin User Data:
+    id: admin-user-data
+    description: User list with emails and roles returned by GET /api/Users.
+    usage: business
+    tags:
+      - admin
+    origin: application
+    owner: Lab Owner
+    quantity: many
+    confidentiality: confidential
+    integrity: critical
+    availability: operational
+    justification_cia_rating: >
+      Exposes every customer's email and role in one response.
+
+
+technical_assets:
+
+  Browser SPA:
+    id: user-browser
+    description: Juice Shop Angular app in the user's browser; keeps the JWT in localStorage.
+    type: external-entity # values: external-entity, process, datastore
+    usage: business # values: business, devops
+    used_as_client_by_human: true
+    out_of_scope: false
+    justification_out_of_scope:
+    size: system # values: system, service, application, component
+    technology: browser # values: see help
+    tags:
+    internet: true
+    machine: virtual # values: physical, virtual, container, serverless
+    encryption: none # values: none, transparent, data-with-symmetric-shared-key, data-with-asymmetric-shared-key, data-with-enduser-individual-key
+    owner: End User
+    confidentiality: internal # values: public, internal, restricted, confidential, strictly-confidential
+    integrity: operational # values: archive, operational, important, critical, mission-critical
+    availability: operational # values: archive, operational, important, critical, mission-critical
+    justification_cia_rating: Controlled by the end user, who may be the attacker.
+    multi_tenant: false
+    redundant: false
+    custom_developed_parts: false
+    data_assets_processed: # sequence of IDs to reference
+      - user-credentials
+      - session-token
+      - admin-user-data
+    data_assets_stored: # sequence of IDs to reference
+      - session-token
+    data_formats_accepted: # sequence of formats like: json, xml, serialization, file, csv
+      - json
+    communication_links:
+      Login Request:
+        target: login-endpoint
+        description: POST /rest/user/login with email and password as JSON; returns the JWT.
+        protocol: https # values: see help
+        authentication: credentials # values: none, credentials, session-id, token, client-certificate, two-factor
+        authorization: enduser-identity-propagation # values: none, technical-user, enduser-identity-propagation
+        tags:
+        vpn: false
+        ip_filtered: false
+        readonly: false
+        usage: business # values: business, devops
+        data_assets_sent: # sequence of IDs to reference
+          - user-credentials
+        data_assets_received: # sequence of IDs to reference
+          - session-token
+      Admin API Call:
+        target: jwt-verifier
+        description: GET /api/Users with an Authorization Bearer JWT (PUT and DELETE on /api/Users/:id are denyAll).
+        protocol: https
+        authentication: token
+        authorization: enduser-identity-propagation
+        tags:
+          - admin
+        vpn: false
+        ip_filtered: false
+        readonly: true
+        usage: business
+        data_assets_sent:
+          - session-token
+        data_assets_received:
+          - admin-user-data
+
+  Login Endpoint:
+    id: login-endpoint
+    description: Express route POST /rest/user/login (routes/login.ts).
+    type: process
+    usage: business
+    used_as_client_by_human: false
+    out_of_scope: false
+    justification_out_of_scope:
+    size: component
+    technology: web-service-rest
+    tags:
+      - nodejs
+      - express
+    internet: false
+    machine: container
+    encryption: none
+    owner: Lab Owner
+    confidentiality: confidential
+    integrity: critical
+    availability: important
+    justification_cia_rating: Handles plaintext passwords and decides who gets a token.
+    multi_tenant: false
+    redundant: false
+    custom_developed_parts: true
+    data_assets_processed:
+      - user-credentials
+      - session-token
+    data_assets_stored:
+    data_formats_accepted:
+      - json
+    communication_links:
+      Credential Lookup:
+        target: credential-store
+        description: >
+          Raw sequelize.query() SELECT on the Users table with the email and the
+          password hash interpolated straight into the SQL string.
+        protocol: sql-access-protocol
+        authentication: credentials
+        authorization: technical-user
+        tags:
+          - sqlite
+        vpn: false
+        ip_filtered: false
+        readonly: true
+        usage: business
+        data_assets_sent:
+          - user-credentials
+        data_assets_received:
+          - user-credentials
+      Issue Token:
+        target: token-issuer
+        description: In-process call to security.authorize() with the matched user row as the token payload.
+        protocol: in-process-library-call
+        authentication: externalized
+        authorization: enduser-identity-propagation
+        tags:
+          - jwt
+        vpn: false
+        ip_filtered: false
+        readonly: false
+        usage: business
+        data_assets_sent:
+          - user-credentials
+        data_assets_received:
+          - session-token
+
+  Token Issuer:
+    id: token-issuer
+    description: lib/insecurity authorize() signs an RS256 JWT; the private key is hard-coded in the source.
+    type: process
+    usage: business
+    used_as_client_by_human: false
+    out_of_scope: false
+    justification_out_of_scope:
+    size: component
+    technology: library
+    tags:
+      - nodejs
+      - jwt
+    internet: false
+    machine: container
+    encryption: none
+    owner: Lab Owner
+    confidentiality: strictly-confidential
+    integrity: critical
+    availability: important
+    justification_cia_rating: Holds the signing key, so it can impersonate every user.
+    multi_tenant: false
+    redundant: false
+    custom_developed_parts: true
+    data_assets_processed:
+      - user-credentials
+      - session-token
+      - jwt-signing-key
+    data_assets_stored:
+      - jwt-signing-key
+    data_formats_accepted:
+      - json
+    communication_links:
+
+  JWT Verifier:
+    id: jwt-verifier
+    description: security.isAuthorized() - express-jwt verifies the RS256 signature with encryptionkeys/jwt.pub in front of /api/Users; it does not read the role claim.
+    type: process
+    usage: business
+    used_as_client_by_human: false
+    out_of_scope: false
+    justification_out_of_scope:
+    size: component
+    technology: gateway
+    tags:
+      - express
+      - authz-check
+    internet: false
+    machine: container
+    encryption: none
+    owner: Lab Owner
+    confidentiality: confidential
+    integrity: critical
+    availability: important
+    justification_cia_rating: The only thing standing between a token and the admin API.
+    multi_tenant: false
+    redundant: false
+    custom_developed_parts: true
+    data_assets_processed:
+      - session-token
+      - admin-user-data
+    data_assets_stored:
+    data_formats_accepted:
+      - json
+    communication_links:
+      Authorized Admin Request:
+        target: admin-endpoint
+        description: >
+          The authorisation check in front of the admin endpoint, registered in server.js as
+          app.get('/api/Users', security.isAuthorized()). A request without a validly signed
+          JWT gets 401 here. In v20 it authorises on the token's user identity only and
+          does not require role admin.
+        protocol: in-process-library-call
+        authentication: token
+        authorization: enduser-identity-propagation
+        tags:
+          - authz-check
+          - admin
+        vpn: false
+        ip_filtered: false
+        readonly: true
+        usage: business
+        data_assets_sent:
+        data_assets_received:
+          - admin-user-data
+
+  Admin Endpoint:
+    id: admin-endpoint
+    description: /api/Users route handler that returns the full user list, called in-process once the verifier lets a request through.
+    type: process
+    usage: business
+    used_as_client_by_human: false
+    out_of_scope: false
+    justification_out_of_scope:
+    size: component
+    technology: library
+    tags:
+      - express
+      - admin
+    internet: false
+    machine: container
+    encryption: none
+    owner: Lab Owner
+    confidentiality: confidential
+    integrity: critical
+    availability: important
+    justification_cia_rating: Returns every account with its email and role.
+    multi_tenant: false
+    redundant: false
+    custom_developed_parts: true
+    data_assets_processed:
+      - admin-user-data
+    data_assets_stored:
+    data_formats_accepted:
+      - json
+    communication_links:
+      User Management Query:
+        target: credential-store
+        description: Sequelize SELECT on the Users table for the user list.
+        protocol: sql-access-protocol
+        authentication: credentials
+        authorization: technical-user
+        tags:
+          - sqlite
+        vpn: false
+        ip_filtered: false
+        readonly: true
+        usage: business
+        data_assets_sent:
+        data_assets_received:
+          - admin-user-data
+
+  Credential Store:
+    id: credential-store
+    description: SQLite database file inside the container (data/juiceshop.sqlite), Users table.
+    type: datastore
+    usage: business
+    used_as_client_by_human: false
+    out_of_scope: false
+    justification_out_of_scope:
+    size: component
+    technology: identity-store-database
+    tags:
+      - sqlite
+    internet: false
+    machine: container
+    encryption: none
+    owner: Lab Owner
+    confidentiality: confidential
+    integrity: critical
+    availability: important
+    justification_cia_rating: Every account, hash and role lives in this one file.
+    multi_tenant: false
+    redundant: false
+    custom_developed_parts: false
+    data_assets_processed:
+    data_assets_stored:
+      - user-credentials
+      - admin-user-data
+    data_formats_accepted:
+      - file
+    communication_links:
+
+
+trust_boundaries:
+
+  Juice Shop Container:
+    id: juice-shop-container
+    description: Docker container network namespace of the Juice Shop image.
+    type: network-virtual-lan # values: see help
+    tags:
+    technical_assets_inside: # sequence of IDs to reference
+      - credential-store
+    trust_boundaries_nested: # sequence of IDs to reference
+      - node-process
+
+  Node.js Process:
+    id: node-process
+    description: The single Node.js/Express process that serves every route.
+    type: execution-environment
+    tags:
+    technical_assets_inside:
+      - login-endpoint
+      - token-issuer
+      - jwt-verifier
+      - admin-endpoint
+    trust_boundaries_nested:
+
+
+shared_runtimes:
+
+  Juice Shop Node Runtime:
+    id: juice-shop-runtime
+    description: One Node.js runtime hosts the public login route, the key holder and the admin API.
+    tags:
+      - nodejs
+    technical_assets_running: # sequence of IDs to reference
+      - login-endpoint
+      - token-issuer
+      - jwt-verifier
+      - admin-endpoint
+
+
+individual_risk_categories: # used for adding custom manually identified risks
+
+
+risk_tracking:

--- a/labs/lab2/threagile-model-secure.yaml
+++ b/labs/lab2/threagile-model-secure.yaml
@@ -1,0 +1,429 @@
+threagile_version: 1.0.0
+
+title: OWASP Juice Shop Secure Model
+date: 2025-09-18
+
+author:
+  name: Student Name
+  homepage: https://example.edu
+
+management_summary_comment: >
+  Threat model for a local OWASP Juice Shop setup. Users access the app  
+  either directly via HTTP on port 3000 or through an optional reverse proxy that  
+  terminates TLS and adds security headers. The app runs in a container  
+  and writes data to a host-mounted volume (for database, uploads, logs).  
+  Optional outbound notifications (e.g., a challenge-solution WebHook) can be configured for integrations.
+
+business_criticality: important  # archive, operational, important, critical, mission-critical
+
+business_overview:
+  description: >
+    Training environment for DevSecOps. This model covers a deliberately vulnerable  
+    web application (OWASP Juice Shop) running locally in a Docker container. The focus is on a minimal architecture, STRIDE threat analysis, and actionable mitigations for the identified risks.
+
+  images:
+    # - dfd.png: Data Flow Diagram (if exported from the tool)
+
+technical_overview:
+  description: >
+    A user’s web browser connects to the Juice Shop application (Node.js/Express server) either directly on **localhost:3000** (HTTP) or via a **reverse proxy** on ports 80/443 (with HTTPS). The Juice Shop server may issue outbound requests to external services (e.g., a configured **WebHook** for solved challenge notifications). All application data (the SQLite database, file uploads, logs) is stored on the host’s filesystem via a mounted volume. Key trust boundaries include the **Internet** (user & external services) → **Host** (local machine/VM) → **Container Network** (isolated app container).
+  images: []
+
+questions:
+  Do you expose port 3000 beyond localhost?: ""
+  Do you use a reverse proxy with TLS and security headers?: ""
+  Are any outbound integrations (webhooks) configured?: ""
+  Is any sensitive data stored in logs or files?: ""
+
+abuse_cases:
+  Credential Stuffing / Brute Force: >
+    Attackers attempt repeated login attempts to guess credentials or exhaust system resources.
+  Stored XSS via Product Reviews: >
+    Malicious scripts are inserted into product reviews, getting stored and executed in other users’ browsers.
+  SSRF via Outbound Requests: >
+    Server-side requests (e.g. profile image URL fetch or WebHook callback) are abused to access internal network resources.
+
+security_requirements:
+  TLS in transit: Enforce HTTPS for user traffic via a TLS-terminating reverse proxy with strong ciphers and certificate management.
+  AuthZ on sensitive routes: Implement strict server-side authorization checks (role/permission) on admin or sensitive functionalities.
+  Rate limiting & lockouts: Apply rate limiting and account lockout policies to mitigate brute-force and automated attacks on authentication and expensive operations.
+  Secure headers: Add security headers (HSTS, CSP, X-Frame-Options, X-Content-Type-Options, etc.) at the proxy or app to mitigate client-side attacks.
+  Secrets management: Protect secret keys and credentials (JWT signing keys, OAuth client secrets) – keep them out of code repos and avoid logging them.
+
+tags_available:
+  # Relevant technologies and environment tags
+  - docker
+  - nodejs
+  # Data and asset tags
+  - pii
+  - auth
+  - tokens
+  - logs
+  - public
+  - actor
+  - user
+  - optional
+  - proxy
+  - app
+  - storage
+  - volume
+  - saas
+  - webhook
+  # Communication tags
+  - primary
+  - direct
+  - egress
+
+# =========================
+# DATA ASSETS
+# =========================
+data_assets:
+
+  User Accounts:
+    id: user-accounts
+    description: "User profile data, credential hashes, emails."
+    usage: business
+    tags: ["pii", "auth"]
+    origin: user-supplied
+    owner: Lab Owner
+    quantity: many
+    confidentiality: confidential
+    integrity: critical
+    availability: important
+    justification_cia_rating: >
+      Contains personal identifiers and authentication data. High confidentiality is required to protect user privacy, and integrity is critical to prevent account takeovers.
+
+  Orders:
+    id: orders
+    description: "Order history, addresses, and payment metadata (no raw card numbers)."
+    usage: business
+    tags: ["pii"]
+    origin: application
+    owner: Lab Owner
+    quantity: many
+    confidentiality: confidential
+    integrity: important
+    availability: important
+    justification_cia_rating: >
+      Contains users’ personal data and business transaction records. Integrity and confidentiality are important to prevent fraud or privacy breaches.
+
+  Product Catalog:
+    id: product-catalog
+    description: "Product information (names, descriptions, prices) available to all users."
+    usage: business
+    tags: ["public"]
+    origin: application
+    owner: Lab Owner
+    quantity: many
+    confidentiality: public
+    integrity: important
+    availability: important
+    justification_cia_rating: >
+      Product data is intended to be public, but its integrity is important (to avoid defacement or price manipulation that could mislead users).
+
+  Tokens & Sessions:
+    id: tokens-sessions
+    description: "Session identifiers, JWTs for authenticated sessions, CSRF tokens."
+    usage: business
+    tags: ["auth", "tokens"]
+    origin: application
+    owner: Lab Owner
+    quantity: many
+    confidentiality: confidential
+    integrity: important
+    availability: important
+    justification_cia_rating: >
+      If session tokens are compromised, attackers can hijack user sessions. They must be kept confidential and intact; availability is less critical (tokens can be reissued).
+
+  Logs:
+    id: logs
+    description: "Application and access logs (may inadvertently contain PII or secrets)."
+    usage: devops
+    tags: ["logs"]
+    origin: application
+    owner: Lab Owner
+    quantity: many
+    confidentiality: internal
+    integrity: important
+    availability: important
+    justification_cia_rating: >
+      Logs are for internal use (troubleshooting, monitoring). They should not be exposed publicly, and sensitive data should be sanitized to protect confidentiality.
+
+# =========================
+# TECHNICAL ASSETS
+# =========================
+technical_assets:
+
+  User Browser:
+    id: user-browser
+    description: "End-user web browser (client)."
+    type: external-entity
+    usage: business
+    used_as_client_by_human: true
+    out_of_scope: false
+    justification_out_of_scope:
+    size: system
+    technology: browser
+    tags: ["actor", "user"]
+    internet: true
+    machine: virtual
+    encryption: none
+    owner: External User
+    confidentiality: public
+    integrity: operational
+    availability: operational
+    justification_cia_rating: "Client controlled by end user (potentially an attacker)."
+    multi_tenant: false
+    redundant: false
+    custom_developed_parts: false
+    data_assets_processed: []
+    data_assets_stored: []
+    data_formats_accepted:
+      - json
+    communication_links:
+      To Reverse Proxy (preferred):
+        target: reverse-proxy
+        description: "User browser to reverse proxy (HTTPS on 443)."
+        protocol: https
+        authentication: session-id
+        authorization: enduser-identity-propagation
+        tags: ["primary"]
+        vpn: false
+        ip_filtered: false
+        readonly: false
+        usage: business
+        data_assets_sent:
+          - tokens-sessions
+        data_assets_received:
+          - product-catalog
+      Direct to App (no proxy):
+        target: juice-shop
+        description: "Direct browser access to app (HTTPS on 3000)."
+        protocol: https
+        authentication: session-id
+        authorization: enduser-identity-propagation
+        tags: ["direct"]
+        vpn: false
+        ip_filtered: false
+        readonly: false
+        usage: business
+        data_assets_sent:
+          - tokens-sessions
+        data_assets_received:
+          - product-catalog
+
+  Reverse Proxy:
+    id: reverse-proxy
+    description: "Optional reverse proxy (e.g., Nginx) for TLS termination and adding security headers."
+    type: process
+    usage: business
+    used_as_client_by_human: false
+    out_of_scope: false
+    justification_out_of_scope:
+    size: application
+    technology: reverse-proxy
+    tags: ["optional", "proxy"]
+    internet: false
+    machine: virtual
+    encryption: transparent
+    owner: Lab Owner
+    confidentiality: internal
+    integrity: important
+    availability: important
+    justification_cia_rating: "Not exposed to internet directly; improves security of inbound traffic."
+    multi_tenant: false
+    redundant: false
+    custom_developed_parts: false
+    data_assets_processed:
+      - product-catalog
+      - tokens-sessions
+    data_assets_stored: []
+    data_formats_accepted:
+      - json
+    communication_links:
+      To App:
+        target: juice-shop
+        description: "Proxy forwarding to app over HTTPS with a mutual-TLS client certificate."
+        protocol: https
+        authentication: client-certificate
+        authorization: enduser-identity-propagation
+        tags: []
+        vpn: false
+        ip_filtered: false
+        readonly: false
+        usage: business
+        data_assets_sent:
+          - tokens-sessions
+        data_assets_received:
+          - product-catalog
+
+  Juice Shop Application:
+    id: juice-shop
+    description: "OWASP Juice Shop server (Node.js/Express, v19.0.0)."
+    type: process
+    usage: business
+    used_as_client_by_human: false
+    out_of_scope: false
+    justification_out_of_scope:
+    size: application
+    technology: web-server
+    tags: ["app", "nodejs"]
+    internet: false
+    machine: container
+    encryption: transparent
+    owner: Lab Owner
+    confidentiality: internal
+    integrity: important
+    availability: important
+    justification_cia_rating: "In-scope web application (contains all business logic and vulnerabilities by design)."
+    multi_tenant: false
+    redundant: false
+    custom_developed_parts: true
+    data_assets_processed:
+      - user-accounts
+      - orders
+      - product-catalog
+      - tokens-sessions
+    data_assets_stored:
+      - logs
+    data_formats_accepted:
+      - json
+    communication_links:
+      To Challenge WebHook:
+        target: webhook-endpoint
+        description: "Optional outbound callback (HTTP POST) to external WebHook when a challenge is solved."
+        protocol: https
+        authentication: none
+        authorization: none
+        tags: ["egress"]
+        vpn: false
+        ip_filtered: false
+        readonly: false
+        usage: business
+        data_assets_sent:
+          - orders
+
+  Persistent Storage:
+    id: persistent-storage
+    description: "Host-mounted volume for database, file uploads, and logs."
+    type: datastore
+    usage: devops
+    used_as_client_by_human: false
+    out_of_scope: false
+    justification_out_of_scope:
+    size: component
+    technology: file-server
+    tags: ["storage", "volume"]
+    internet: false
+    machine: virtual
+    encryption: transparent
+    owner: Lab Owner
+    confidentiality: internal
+    integrity: important
+    availability: important
+    justification_cia_rating: "Local disk storage for the container – not directly exposed, but if compromised it contains sensitive data (database and logs)."
+    multi_tenant: false
+    redundant: false
+    custom_developed_parts: false
+    data_assets_processed: []
+    data_assets_stored:
+      - logs
+      - user-accounts
+      - orders
+      - product-catalog
+    data_formats_accepted:
+      - file
+    communication_links: {}
+
+  Webhook Endpoint:
+    id: webhook-endpoint
+    description: "External WebHook service (3rd-party, if configured for integrations)."
+    type: external-entity
+    usage: business
+    used_as_client_by_human: false
+    out_of_scope: true
+    justification_out_of_scope: "Third-party service to receive notifications (not under our control)."
+    size: system
+    technology: web-service-rest
+    tags: ["saas", "webhook"]
+    internet: true
+    machine: virtual
+    encryption: none
+    owner: Third-Party
+    confidentiality: internal
+    integrity: operational
+    availability: operational
+    justification_cia_rating: "External service that receives data (like order or challenge info). Treated as a trusted integration point but could be abused if misconfigured."
+    multi_tenant: true
+    redundant: true
+    custom_developed_parts: false
+    data_assets_processed:
+      - orders
+    data_assets_stored: []
+    data_formats_accepted:
+      - json
+    communication_links: {}
+
+# =========================
+# TRUST BOUNDARIES
+# =========================
+trust_boundaries:
+
+  Internet:
+    id: internet
+    description: "Untrusted public network (Internet)."
+    type: network-dedicated-hoster
+    tags: []
+    technical_assets_inside:
+      - user-browser
+      - webhook-endpoint
+    trust_boundaries_nested:
+      - host
+
+  Host:
+    id: host
+    description: "Local host machine / VM running the Docker environment."
+    type: network-dedicated-hoster
+    tags: []
+    technical_assets_inside:
+      - reverse-proxy
+      - persistent-storage
+    trust_boundaries_nested:
+      - container-network
+
+  Container Network:
+    id: container-network
+    description: "Docker container network (isolated internal network for containers)."
+    type: network-dedicated-hoster
+    tags: []
+    technical_assets_inside:
+      - juice-shop
+    trust_boundaries_nested: []
+
+# =========================
+# SHARED RUNTIMES
+# =========================
+shared_runtimes:
+
+  Docker Host:
+    id: docker-host
+    description: "Docker Engine and default bridge network on the host."
+    tags: ["docker"]
+    technical_assets_running:
+      - juice-shop
+      # If the reverse proxy is containerized, include it:
+      # - reverse-proxy
+
+# =========================
+# INDIVIDUAL RISK CATEGORIES (optional)
+# =========================
+individual_risk_categories: {}
+
+# =========================
+# RISK TRACKING (optional)
+# =========================
+risk_tracking: {}
+
+# (Optional diagram layout tweaks can be added here)
+#diagram_tweak_edge_layout: spline
+#diagram_tweak_layout_left_to_right: true

--- a/submissions/lab2.md
+++ b/submissions/lab2.md
@@ -1,0 +1,224 @@
+# Lab 2 — Threat Modeling: STRIDE on Juice Shop with Threagile
+
+**Environment:**
+- Windows 11 host, Docker Desktop 29.7.2.
+- Threagile image `threagile/threagile:0.9.1` (`sha256:abb9eccb111a2059c4876759a24245db02ad295b1608d3a4634ec250f38d9640`). The binary inside reports `Version: 1.0.0 (20240730113903)`.
+- `jq` is not installed here, so the 2.2, 2.3 and 2.5 queries ran as a small Python script with the same logic: array length, group by `severity`, a stable sort by the explicit `critical, high, elevated, medium, low` order, and a set difference of `category` values.
+
+## Task 1
+
+### 2.1 Baseline run
+
+```bash
+docker run --rm -v "$(pwd)/labs/lab2":/app/work \
+  threagile/threagile:0.9.1 \
+  -model /app/work/threagile-model.yaml -output /app/work/output
+ls labs/lab2/output/
+```
+
+```text
+data-asset-diagram.png  data-flow-diagram.png  report.pdf  risks.json  risks.xlsx  stats.json  tags.xlsx  technical-assets.json
+```
+
+The run exited with code 0. Apart from repeated `Fontconfig error: No writable cache directories` lines, it printed no errors.
+
+### 2.2 Severity counts
+
+`length` of `risks.json`: **23**
+
+| Severity | Count |
+|---|---|
+| critical | 0 |
+| high | 0 |
+| elevated | 4 |
+| medium | 14 |
+| low | 5 |
+| **Total** | **23** |
+
+`stats.json` has the same numbers, all with status `unchecked`.
+
+### 2.3 Top five
+
+```text
+elevated	missing-authentication	juice-shop
+elevated	unencrypted-communication	user-browser
+elevated	unencrypted-communication	reverse-proxy
+elevated	cross-site-scripting	juice-shop
+medium	server-side-request-forgery	juice-shop
+```
+
+| # | Rule (asset, link) | STRIDE | Why |
+|---|---|---|---|
+| 1 | `missing-authentication` (`juice-shop`, link `reverse-proxy>to-app`) | **E** — Elevation of Privilege | The app accepts every request on the proxy link without checking who sent it. Anything that reaches port 3000 inside the Docker network gets the proxy's level of trust and skips the proxy's TLS and header controls. |
+| 2 | `unencrypted-communication` (`user-browser`, link `user-browser>direct-to-app-no-proxy`) | **I** — Information Disclosure | Session IDs and JWTs (`tokens-sessions`) travel over plain HTTP on port 3000, so anyone on the network path can read them and replay the session. |
+| 3 | `unencrypted-communication` (`reverse-proxy`, link `reverse-proxy>to-app`) | **I** — Information Disclosure | TLS ends at the proxy and the same tokens continue to the container in clear text, readable by anything that can sniff the host's Docker bridge. |
+| 4 | `cross-site-scripting` (`juice-shop`) | **T** — Tampering | A script injected through, for example, a product review changes the page other users load and runs inside their session. |
+| 5 | `server-side-request-forgery` (`juice-shop`, link `juice-shop>to-challenge-webhook`) | **I** — Information Disclosure | The server sends outbound requests to a configurable webhook URL, and a server that fetches attacker-influenced URLs can be pointed at internal addresses and return what it finds there. |
+
+The STRIDE letters are Threagile's own classification, taken from the `STRIDE` column of `risks.xlsx`.
+
+### Trust-boundary crossing
+
+**Arrow:** User Browser → Juice Shop Application, link **"Direct to App (no proxy)"**, protocol `http`. It is row 2 of the top five (`unencrypted-communication@user-browser>direct-to-app-no-proxy`).
+
+**Boundaries crossed:** the arrow starts in the **Internet** boundary and ends inside **Container Network**. In one hop it crosses Internet → Host and Host → Container Network, and it never passes the reverse proxy.
+
+**Why it is worth an attacker's time:**
+- It is the only path from the untrusted zone straight into the application. It skips the proxy's TLS termination and security headers.
+- It carries session tokens in clear text. Its impact is `high`, the highest in the top five.
+- Nothing sits between the untrusted zone and the app, so it is the shortest route for the injection payloads Juice Shop is built to be vulnerable to.
+
+Binding the container to `127.0.0.1` in Lab 1 is exactly the control that removes the Internet end of this arrow.
+
+## Task 2
+
+### 2.4 Hardening changes
+
+`labs/lab2/threagile-model-secure.yaml` is a copy of the baseline with these field changes and nothing else. No assets or links were added.
+
+| Asset / link | Field | Baseline | Secure |
+|---|---|---|---|
+| model | `title` | `OWASP Juice Shop Threat Model` | `OWASP Juice Shop Secure Model` (29 characters) |
+| link `Direct to App (no proxy)` (browser → app) | `protocol` | `http` | `https` |
+| link `To App` (reverse proxy → app) | `protocol` | `http` | `https` |
+| link `To App` | `authentication` | `none` | `client-certificate` |
+| link `To App` | `authorization` | `none` | `enduser-identity-propagation` |
+| asset `juice-shop` | `encryption` | `none` | `transparent` |
+| asset `persistent-storage` | `encryption` | `none` | `transparent` |
+
+What the values mean:
+- **`client-certificate`:** the proxy authenticates to the app with mutual TLS.
+- **`enduser-identity-propagation`:** the proxy passes the user's JWT through, and the app keeps authorising on the end user.
+- **`transparent`:** disk or volume encryption (BitLocker on the host, LUKS for the volume) that the application does not see.
+
+The two link descriptions were updated to match the new values.
+
+### 2.5 Secure run and diff
+
+```bash
+docker run --rm -v "$(pwd)/labs/lab2":/app/work \
+  threagile/threagile:0.9.1 \
+  -model /app/work/threagile-model-secure.yaml -output /app/work/output-secure
+```
+
+The run exited with code 0 and wrote the full set of outputs, including `report.pdf` and `risks.xlsx`, to `labs/lab2/output-secure/`. `length` of the secure `risks.json`: **18**.
+
+| Severity | Baseline | Secure | Delta |
+|---|---|---|---|
+| critical | 0 | 0 | 0 |
+| high | 0 | 0 | 0 |
+| elevated | 4 | 1 | −3 |
+| medium | 14 | 12 | −2 |
+| low | 5 | 5 | 0 |
+| **Total** | **23** | **18** | **−5 (−22 %)** |
+
+```text
+gone:
+missing-authentication
+unencrypted-asset
+unencrypted-communication
+new:
+```
+
+| Rule gone | Instances | Field change that removed it |
+|---|---|---|
+| `unencrypted-communication` | 2 → 0 | `protocol: http` → `https` on `Direct to App (no proxy)` and on `To App` |
+| `missing-authentication` | 1 → 0 | `authentication: none` → `client-certificate` on `To App` |
+| `unencrypted-asset` | 2 → 0 | `encryption: none` → `transparent` on `juice-shop` and `persistent-storage` |
+
+### Two rules that still fire
+
+- **`cross-site-scripting`** (elevated, `juice-shop`). Threagile raises it for every web application with custom-developed parts, because XSS is a defect in how the code handles and encodes user input. Transport and at-rest encryption do nothing against a script stored in a product review and served to the next visitor. The only YAML "fix" would be to misdescribe the asset's technology.
+- **`container-baseimage-backdooring`** (medium, `juice-shop`). It fires for any asset with `machine: container`, because the risk sits inside the image: its base layers and npm dependencies. TLS and disk encryption faithfully protect a backdoored image. Only provenance controls address it, such as pinning by digest, SBOMs, scanning and signing (Labs 4, 5 and 8), and those are processes outside the model.
+
+### What is left
+
+The 18 remaining risks fall into four groups:
+- **Code-level:** XSS, CSRF, SSRF.
+- **Supply chain and build:** base-image backdooring, missing build infrastructure.
+- **Missing security components and operational gaps:** hardening, vault, 2FA, WAF, identity store.
+- **Model hygiene (the four `low` findings):** `unnecessary-data-transfer` and `unnecessary-technical-asset`. They point at gaps in the model rather than in the system.
+
+Apart from the model-hygiene findings, which a more complete model would clear, none of them depends on an enum value that a model edit can flip. Closing them takes changes in the code with tests to prove them, pipeline controls around the image, and real components (a vault, a WAF, an identity provider with 2FA) added to the architecture and then to the model. `cross-site-scripting` is one that no YAML edit can close: the flaw lives in Juice Shop's source. Even after a fix, the model can only record it as `mitigated` under `risk_tracking`, and it still appears in `risks.json`.
+
+## Bonus
+
+### The model
+
+I wrote `labs/lab2/threagile-model-auth.yaml` from the `-create-stub-model` skeleton. It covers only the login path.
+
+**Technical assets (6):**
+
+| Asset | What it is |
+|---|---|
+| `user-browser` | The single-page app; keeps the JWT in localStorage |
+| `login-endpoint` | `POST /rest/user/login` |
+| `token-issuer` | `lib/insecurity`, signs the JWT |
+| `jwt-verifier` | `security.isAuthorized()`: express-jwt signature check in front of `/api/Users` |
+| `admin-endpoint` | The `/api/Users` handler that returns the user list |
+| `credential-store` | The SQLite `Users` table |
+
+**Data assets (4):**
+- `user-credentials`
+- `jwt-signing-key`: its own `strictly-confidential` data asset, stored only in `token-issuer`
+- `session-token`
+- `admin-user-data`
+
+**Communication links (6).** Every link declares both `authentication` and `authorization`, and none of them uses `none`:
+
+| Link | Protocol | `authentication` | `authorization` |
+|---|---|---|---|
+| Login Request (browser → login-endpoint) | `https` | `credentials` | `enduser-identity-propagation` |
+| Admin API Call (browser → jwt-verifier) | `https` | `token` | `enduser-identity-propagation` |
+| Credential Lookup (login-endpoint → credential-store) | `sql-access-protocol` | `credentials` | `technical-user` |
+| Issue Token (login-endpoint → token-issuer) | `in-process-library-call` | `externalized` | `enduser-identity-propagation` |
+| Authorized Admin Request (jwt-verifier → admin-endpoint) | `in-process-library-call` | `token` | `enduser-identity-propagation` |
+| User Management Query (admin-endpoint → credential-store) | `sql-access-protocol` | `credentials` | `technical-user` |
+
+**The admin authorisation check** is the link `Authorized Admin Request`, tagged `authz-check`:
+- It is the only incoming link of `admin-endpoint`. The browser has no direct link to the admin endpoint.
+- Its description records what the check really does in v20. `server.js` registers `app.get('/api/Users', security.isAuthorized())`, and `isAuthorized()` is express-jwt with the public key. A request without a validly signed JWT gets 401, but nothing checks that the role claim is `admin`.
+
+**Checked against the code.** I copied `server.js`, `lib/insecurity.js` and `routes/login.js` (compiled files under `/juice-shop/build/`) out of the Lab 1 container with `docker cp` and aligned the model with them:
+- `routes/login.js`:54 builds the login query with the email and the password hash interpolated into raw SQL.
+- `lib/insecurity.js`:46 hard-codes the RSA private key, and line 63 signs tokens with `RS256`.
+- `server.js`:353 protects `GET /api/Users` with `isAuthorized()` only. Lines 354-357 deny `PUT` and `DELETE` on `/api/Users/:id` to everyone, so the admin links in the model are read-only.
+- The model lists "Customer reads the user list" as an abuse case for the missing role check.
+
+**Trust boundaries:**
+- `juice-shop-container` (`network-virtual-lan`) holds the credential store.
+- Inside it, `node-process` (`execution-environment`) holds the four code components.
+- The shared runtime `juice-shop-runtime` runs those four components.
+
+**One correction after the first run.** In the first version, `token-issuer` was `identity-provider` and `admin-endpoint` was `web-service-rest`. Threagile's `wrong-communication-link-content` rule flagged that an `in-process-library-call` must target a `library`. Both are in fact modules that Express calls in-process, so I switched them to `library`. The results below come from the corrected model.
+
+### Severity table
+
+```bash
+docker run --rm -v "$(pwd)/labs/lab2":/app/work \
+  threagile/threagile:0.9.1 \
+  -model /app/work/threagile-model-auth.yaml -output /app/work/output-auth
+```
+
+| Severity | Count |
+|---|---|
+| critical | 0 |
+| high | 0 |
+| elevated | 3 |
+| medium | 21 |
+| low | 1 |
+| **Total** | **25** |
+
+### Three risks the baseline model did not surface
+
+| Rule ID | Where | STRIDE | Mitigation |
+|---|---|---|---|
+| `sql-nosql-injection` (elevated, likelihood `very-likely`) | `login-endpoint` via `Credential Lookup`; a second instance on `admin-endpoint` via `User Management Query` | **T** — Tampering | Query the `Users` table only with bound parameters (Sequelize `where` or `replacements`) instead of the string-interpolated `sequelize.query()` in the login route, which is the bug behind Juice Shop's `' OR 1=1--` admin login. |
+| `missing-identity-provider-isolation` (medium, impact `high`) | `credential-store` | **E** — Elevation of Privilege | Move the credential store and token signing into a separate identity service with its own network trust boundary, reachable only from the login and verification paths, so that a compromised product or admin route cannot reach the hashes. |
+| `mixed-targets-on-shared-runtime` (medium) | `juice-shop-runtime`: public login route, key-holding token issuer and admin API in one Node.js runtime | **E** — Elevation of Privilege | Move token signing out of the shared runtime into a separate process, vault or HSM that signs on request, so that code execution in any public route no longer exposes the key now hard-coded in `lib/insecurity`. |
+
+The STRIDE letters come from the `STRIDE` column of `labs/lab2/output-auth/risks.xlsx`.
+
+### What the feature-level model showed
+
+The architecture model draws Juice Shop as one `web-server` box, so Threagile could only raise generic risks for it (XSS, CSRF, SSRF) and never saw that the login query, the signing key and the admin API sit side by side in one Node.js process. Splitting the login path into its real parts exposed the injectable SQL link to the credential store, the hard-coded signing key inside the shared runtime and a check in front of `/api/Users` that verifies the token but never the admin role, which is exactly where Juice Shop's login SQL injection, JWT forgery and user-list exposure problems live.


### PR DESCRIPTION
## Goal

Threat-model the Lab 1 Juice Shop deployment with Threagile (STRIDE), harden the model, measure what the hardening removes, and model the login flow on its own.

## Changes

- `labs/lab2/threagile-model-secure.yaml`: baseline copy with HTTPS on both links into the app, a client-certificate on proxy → app, and `transparent` encryption on the app and the storage
- `labs/lab2/threagile-model-auth.yaml`: feature-level login-flow model written from the stub (6 technical assets, 6 links, 4 data assets including the JWT signing key), checked against the Juice Shop v20 code
- `submissions/lab2.md`: Task 1, Task 2 and Bonus write-ups

## Testing

```bash
docker run --rm -v "$(pwd)/labs/lab2":/app/work threagile/threagile:0.9.1 -model /app/work/threagile-model.yaml -output /app/work/output
docker run --rm -v "$(pwd)/labs/lab2":/app/work threagile/threagile:0.9.1 -model /app/work/threagile-model-secure.yaml -output /app/work/output-secure
docker run --rm -v "$(pwd)/labs/lab2":/app/work threagile/threagile:0.9.1 -model /app/work/threagile-model-auth.yaml -output /app/work/output-auth
```

```text
baseline: 23 risks (elevated 4, medium 14, low 5)
secure:   18 risks (elevated 1, medium 12, low 5), gone: missing-authentication, unencrypted-asset, unencrypted-communication; new: none
auth:     25 risks (elevated 3, medium 21, low 1), no model-failure rules
```

## Artifacts & Screenshots

- Report: `submissions/lab2.md`
- Generated reports (`labs/lab2/output*/`) are gitignored and not committed

## Checklist

- [x] PR title follows `feat(labN): <topic>`
- [x] No secrets or large temp files committed
- [x] `submissions/labN.md` exists
